### PR TITLE
Persist profile skip locks across config resets

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,27 @@
+# Contributing
+
+## Smoke tests
+
+Перед PR по profile lock / profile skip логике запустите:
+
+```bash
+bash tests/profile_lock_smoke.sh
+```
+
+Тест работает только во временной директории в `/tmp`:
+
+- не пишет в `/opt`;
+- не запускает настоящий `zapret2`;
+- проверяет `bash -n` для основных shell-файлов;
+- проверяет persistent state: `auto` как отсутствие записи, `0`, `N`, `clear`;
+- проверяет, что `locked.lua` содержит ветку `0 -> VERDICT_PASS`;
+- проверяет повторное применение состояния к свежему `config`;
+- проверяет `RKN`, `Discord TCP`, `VOICE UDP`, fallback TLS;
+- проверяет, что `VOICE_UDP=0` убирает voice-порты из `NFQWS2_PORTS_UDP`;
+- проверяет идемпотентность `profile_apply_all`.
+
+Успешный результат:
+
+```text
+profile_lock smoke ok
+```

--- a/lib/actions.sh
+++ b/lib/actions.sh
@@ -69,6 +69,8 @@ menu_action_update_config_reset() {
     config_keenetic_set_wan_iface /opt/zapret2/config.default
   fi
 
+  profile_apply_all /opt/zapret2/config.default
+
   cp -f /opt/zapret2/config.default /opt/zapret2/config
   # После копирования синхронизируем рабочий конфиг, чтобы reset не терял IFACE_WAN.
   if [ "$hardware" = "keenetic" ]; then

--- a/lib/config.sh
+++ b/lib/config.sh
@@ -362,3 +362,256 @@ config_tcp443_set_strategy() {
     END{exit((target==0 || changed)?0:1)}
   ' "$cfg" > "${cfg}.tmp" && mv "${cfg}.tmp" "$cfg"
 }
+
+config_profile_proto_list() {
+  case "$1" in
+    1) echo "tls http" ;;
+    2|3|4|8) echo "tls" ;;
+    5|6|7) echo "udp" ;;
+    9) echo "http" ;;
+    *) echo "" ;;
+  esac
+}
+
+config_csv_contains_token() {
+  local csv="$1"
+  local token="$2"
+  local old_ifs="$IFS"
+  local t
+
+  [ -n "$csv" ] || return 1
+  IFS=','
+  for t in $csv; do
+    [ "$t" = "$token" ] && { IFS="$old_ifs"; return 0; }
+  done
+  IFS="$old_ifs"
+  return 1
+}
+
+config_csv_add_tokens() {
+  local csv="$1"
+  local tokens="$2"
+  local old_ifs="$IFS"
+  local token out
+
+  out="$csv"
+  IFS=','
+  for token in $tokens; do
+    [ -n "$token" ] || continue
+    if ! config_csv_contains_token "$out" "$token"; then
+      if [ -n "$out" ]; then
+        out="$out,$token"
+      else
+        out="$token"
+      fi
+    fi
+  done
+  IFS="$old_ifs"
+  printf '%s' "$out"
+}
+
+config_csv_remove_tokens() {
+  local csv="$1"
+  local tokens="$2"
+  local old_ifs="$IFS"
+  local token current out="" keep remove
+
+  IFS=','
+  for current in $csv; do
+    [ -n "$current" ] || continue
+    keep=1
+    for remove in $tokens; do
+      if [ "$current" = "$remove" ]; then
+        keep=0
+        break
+      fi
+    done
+    if [ "$keep" -eq 1 ]; then
+      if [ -n "$out" ]; then
+        out="$out,$current"
+      else
+        out="$current"
+      fi
+    fi
+  done
+  IFS="$old_ifs"
+  printf '%s' "$out"
+}
+
+config_set_csv_var_if_changed() {
+  local cfg="$1"
+  local var="$2"
+  local value="$3"
+  local current
+
+  current="$(config_get_var "$cfg" "$var")"
+  [ "$current" = "$value" ] && return 0
+  config_set_var "$cfg" "$var" "$value"
+}
+
+config_profile_voice_ports() {
+  echo "50000-50099,1400,3478-3481,5349,19294-19344"
+}
+
+config_profile_voice_scripts_disable() {
+  local init="${ZAPRET2_INIT:-/opt/zapret2/init.d/sysv/zapret2}"
+  local custom_dir disabled_dir script
+
+  custom_dir="$(dirname "$init")/custom.d"
+  disabled_dir="${custom_dir}.disabled"
+  for script in 50-discord-media 50-stun4all; do
+    if [ -f "$custom_dir/$script" ]; then
+      mkdir -p "$disabled_dir"
+      mv -f "$custom_dir/$script" "$disabled_dir/$script"
+    fi
+  done
+}
+
+config_profile_voice_ports_apply() {
+  local cfg="$1"
+  local state="$2"
+  local ports new_ports
+
+  [ -f "$cfg" ] || return 0
+  case "$state" in
+    0)
+      ports="$(config_profile_voice_ports)"
+      new_ports="$(config_csv_remove_tokens "$(config_get_var "$cfg" NFQWS2_PORTS_UDP)" "$ports")"
+      [ -n "$new_ports" ] || new_ports="443"
+      config_set_csv_var_if_changed "$cfg" NFQWS2_PORTS_UDP "$new_ports"
+      config_profile_voice_scripts_disable
+      ;;
+    *)
+      ports="$(config_profile_voice_ports)"
+      new_ports="$(config_csv_add_tokens "$(config_get_var "$cfg" NFQWS2_PORTS_UDP)" "$ports")"
+      [ -n "$new_ports" ] || new_ports="$ports"
+      config_set_csv_var_if_changed "$cfg" NFQWS2_PORTS_UDP "$new_ports"
+      config_profile_voice_scripts_disable
+      ;;
+  esac
+}
+
+profile_config_orch_set() {
+  local profile="$1"
+  local proto="$2"
+  local strategy="$3"
+  local saved_lock_file="$ORCH_LOCK_FILE"
+  local rc=0
+
+  if [ "$profile" = "8" ] || [ "$profile" = "9" ]; then
+    ORCH_LOCK_FILE="$ORCH_DIR/locked.manual.tsv"
+  fi
+  orch_locked_set "$profile" "$proto" "$strategy" || rc=$?
+  ORCH_LOCK_FILE="$saved_lock_file"
+  return "$rc"
+}
+
+profile_config_orch_clear() {
+  local profile="$1"
+  local proto="$2"
+  local saved_lock_file="$ORCH_LOCK_FILE"
+  local rc=0
+
+  if [ "$profile" = "8" ] || [ "$profile" = "9" ]; then
+    ORCH_LOCK_FILE="$ORCH_DIR/locked.manual.tsv"
+  fi
+  orch_locked_clear "$profile" "$proto" || rc=$?
+  ORCH_LOCK_FILE="$saved_lock_file"
+  return "$rc"
+}
+
+profile_config_apply_state() {
+  local profile="$1"
+  local proto_list="$2"
+  local state="$3"
+  local cfg="$4"
+  local proto normalized max
+
+  cfg="$(config_get_file "$cfg")" || return 0
+  [ -n "$proto_list" ] || proto_list="$(config_profile_proto_list "$profile")"
+  [ -n "$proto_list" ] || return 0
+  normalized="$(profile_state_normalize "$state")" || return 2
+
+  case "$normalized" in
+    auto)
+      for proto in $proto_list; do
+        profile_config_orch_clear "$profile" "$proto" || return 1
+      done
+      if [ "$profile" = "6" ]; then
+        config_profile_voice_ports_apply "$cfg" auto
+      fi
+      ;;
+    0)
+      for proto in $proto_list; do
+        profile_config_orch_set "$profile" "$proto" 0 || return 1
+      done
+      if [ "$profile" = "6" ]; then
+        config_profile_voice_ports_apply "$cfg" 0
+      fi
+      ;;
+    *)
+      max="$(config_profile_max_strategy "$profile" "$cfg")"
+      if ! printf '%s' "$max" | grep -Eq '^[1-9][0-9]*$' || [ "$normalized" -gt "$max" ]; then
+        echo "Пропуск сохранённого состояния профиля $profile: стратегия $normalized вне диапазона."
+        return 0
+      fi
+      for proto in $proto_list; do
+        profile_config_orch_set "$profile" "$proto" "$normalized" || return 1
+      done
+      if [ "$profile" = "6" ]; then
+        config_profile_voice_ports_apply "$cfg" "$normalized"
+      fi
+      ;;
+  esac
+}
+
+profile_state_set_and_apply() {
+  local profile="$1"
+  local proto_list="$2"
+  local state="$3"
+  local cfg="$4"
+  local proto normalized
+
+  normalized="$(profile_state_normalize "$state")" || return 1
+  [ -n "$proto_list" ] || proto_list="$(config_profile_proto_list "$profile")"
+  [ -n "$proto_list" ] || return 1
+
+  for proto in $proto_list; do
+    if [ "$normalized" = "auto" ]; then
+      profile_state_clear "$profile" "$proto" || return 1
+    else
+      profile_state_set "$profile" "$proto" "$normalized" || return 1
+    fi
+  done
+  profile_config_apply_state "$profile" "$proto_list" "$normalized" "$cfg"
+}
+
+profile_apply_all() {
+  local cfg="$1"
+  local file profile proto state rest rc
+
+  cfg="$(config_get_file "$cfg")" || return 0
+  file="$(profile_state_file)"
+  [ -f "$file" ] || return 0
+
+  while read -r profile proto state rest; do
+    case "$profile" in
+      ""|\#*) continue ;;
+    esac
+    if [ -z "$state" ]; then
+      state="$proto"
+      proto="$(config_profile_proto_list "$profile")"
+    fi
+    if profile_config_apply_state "$profile" "$proto" "$state" "$cfg"; then
+      continue
+    else
+      rc=$?
+    fi
+    if [ "$rc" -eq 2 ]; then
+      echo "Пропуск сохранённого состояния профиля $profile: некорректное состояние '$state'."
+      continue
+    fi
+    return "$rc"
+  done < "$file"
+  return 0
+}

--- a/lib/orchestra_state.sh
+++ b/lib/orchestra_state.sh
@@ -2,6 +2,7 @@
 
 ORCH_DIR="${ORCH_DIR:-/opt/zapret2/extra_strats/cache/orchestra}"
 ORCH_LOCK_FILE="${ORCH_LOCK_FILE:-$ORCH_DIR/locked.tsv}"
+PROFILE_STATE_FILE="${PROFILE_STATE_FILE:-${Z2R_PROFILE_STATE_FILE:-/opt/etc/z2r/profile.lock}}"
 
 orch_locked_get() {
   local profile="$1"
@@ -13,13 +14,23 @@ orch_locked_get() {
   } END{if (!found) print 0}' "$ORCH_LOCK_FILE"
 }
 
+orch_locked_state_get() {
+  local profile="$1"
+  local proto="$2"
+  [ -f "$ORCH_LOCK_FILE" ] || { echo "auto"; return; }
+  awk -v pr="$profile" -v p="$proto" 'BEGIN{FS="\t"}{
+    if ($1==pr && $2==p && NF>=3) {print $3; found=1; exit}
+    if ($1==pr && NF==2 && p=="tls") {print $2; found=1; exit}
+  } END{if (!found) print "auto"}' "$ORCH_LOCK_FILE"
+}
+
 orch_locked_set() {
   local profile="$1"
   local proto="$2"
   local strategy="$3"
   local tmp="${ORCH_LOCK_FILE}.tmp"
-  mkdir -p "$(dirname "$ORCH_LOCK_FILE")"
-  touch "$ORCH_LOCK_FILE"
+  mkdir -p "$(dirname "$ORCH_LOCK_FILE")" || return 1
+  touch "$ORCH_LOCK_FILE" || return 1
   awk -v pr="$profile" -v p="$proto" -v s="$strategy" 'BEGIN{FS=OFS="\t"}{
     if ($1==pr && (($2==p) || (NF==2 && p=="tls"))) {print pr,p,s; found=1; next}
     print
@@ -41,4 +52,140 @@ orch_locked_clear() {
 
 zapret2_running() {
   pidof nfqws2 >/dev/null 2>&1
+}
+
+profile_state_file() {
+  printf '%s\n' "$PROFILE_STATE_FILE"
+}
+
+profile_state_normalize() {
+  case "$1" in
+    ""|"auto")
+      echo "auto"
+      ;;
+    "0"|"skip")
+      echo "0"
+      ;;
+    *)
+      if printf '%s' "$1" | grep -Eq '^[1-9][0-9]*$'; then
+        echo "$1"
+      else
+        return 1
+      fi
+      ;;
+  esac
+}
+
+profile_state_stored_get() {
+  local profile="$1"
+  local proto="$2"
+  local file
+  file="$(profile_state_file)"
+
+  [ -f "$file" ] || { echo "auto"; return 0; }
+  awk -v pr="$profile" -v p="$proto" '
+    BEGIN { FS="[ \t]+" }
+    /^[[:space:]]*#/ || NF == 0 { next }
+    $1 == pr && $2 == p && NF >= 3 { print $3; found=1; exit }
+    $1 == pr && NF == 2 && p == "tls" { print $2; found=1; exit }
+    END { if (!found) print "auto" }
+  ' "$file"
+}
+
+profile_state_get() {
+  local profile="$1"
+  local proto="$2"
+  local stored
+
+  stored="$(profile_state_stored_get "$profile" "$proto")"
+  if [ "$stored" != "auto" ]; then
+    profile_state_normalize "$stored" || echo "auto"
+    return 0
+  fi
+
+  profile_state_normalize "$(orch_locked_state_get "$profile" "$proto")" || echo "auto"
+}
+
+profile_state_display() {
+  profile_state_get "$1" "$2"
+}
+
+profile_state_validate_strategy() {
+  local profile="$1"
+  local strategy="$2"
+  local max
+
+  printf '%s' "$strategy" | grep -Eq '^[0-9]+$' || return 1
+  [ "$strategy" = "0" ] && return 0
+  if type config_profile_max_strategy >/dev/null 2>&1; then
+    max="$(config_profile_max_strategy "$profile" 2>/dev/null || true)"
+    if printf '%s' "$max" | grep -Eq '^[1-9][0-9]*$' && [ "$strategy" -gt "$max" ]; then
+      return 1
+    fi
+  fi
+  return 0
+}
+
+profile_state_set() {
+  local profile="$1"
+  local proto="$2"
+  local state
+  local file tmp
+
+  state="$(profile_state_normalize "$3")" || return 1
+  [ "$state" = "auto" ] && { profile_state_clear "$profile" "$proto"; return $?; }
+  profile_state_validate_strategy "$profile" "$state" || return 1
+
+  if [ "$(profile_state_stored_get "$profile" "$proto")" = "$state" ]; then
+    return 0
+  fi
+
+  file="$(profile_state_file)"
+  tmp="${file}.tmp.$$"
+  mkdir -p "$(dirname "$file")"
+  if [ -f "$file" ]; then
+    awk -v pr="$profile" -v p="$proto" '
+      BEGIN { FS=OFS="\t" }
+      /^[[:space:]]*#/ || NF == 0 { print; next }
+      $1 == pr && (($2 == p) || (NF == 2 && p == "tls")) { next }
+      { print }
+    ' "$file" > "$tmp" || { rm -f "$tmp"; return 1; }
+  else
+    : > "$tmp"
+  fi
+  printf '%s\t%s\t%s\n' "$profile" "$proto" "$state" >> "$tmp"
+
+  if [ -f "$file" ] && cmp -s "$file" "$tmp"; then
+    rm -f "$tmp"
+  else
+    mv -f "$tmp" "$file"
+  fi
+}
+
+profile_state_clear() {
+  local profile="$1"
+  local proto="$2"
+  local file tmp
+
+  [ "$(profile_state_stored_get "$profile" "$proto")" = "auto" ] && return 0
+
+  file="$(profile_state_file)"
+  tmp="${file}.tmp.$$"
+  mkdir -p "$(dirname "$file")"
+  if [ -f "$file" ]; then
+    awk -v pr="$profile" -v p="$proto" '
+      BEGIN { FS=OFS="\t" }
+      /^[[:space:]]*#/ || NF == 0 { print; next }
+      $1 == pr && (($2 == p) || (NF == 2 && p == "tls")) { next }
+      { print }
+    ' "$file" > "$tmp" || { rm -f "$tmp"; return 1; }
+  else
+    : > "$tmp"
+  fi
+
+  if [ -f "$file" ] && cmp -s "$file" "$tmp"; then
+    rm -f "$tmp"
+  else
+    mv -f "$tmp" "$file"
+  fi
 }

--- a/lib/strategies.sh
+++ b/lib/strategies.sh
@@ -1,16 +1,20 @@
 # Функция для генерации строки статуса стратегий
 get_current_strategies_info() {
     local s_udp s_tcp s_gv s_rkn
-    s_udp="$(orch_locked_get 5 udp)"
-    s_tcp="$(orch_locked_get 1 tls)"
-    s_gv="$(orch_locked_get 2 tls)"
-    s_rkn="$(orch_locked_get 3 tls)"
+    s_udp="$(profile_state_display 5 udp)"
+    s_tcp="$(profile_state_display 1 tls)"
+    s_gv="$(profile_state_display 2 tls)"
+    s_rkn="$(profile_state_display 3 tls)"
 
     colorize_num() {
-        if ! printf "%s" "$1" | grep -Eq '^[0-9]+$' || [ "$1" -le 0 ]; then
-            echo "${gray}Def${plain}"
-        else
+        if [ "$1" = "auto" ]; then
+            echo "${gray}auto${plain}"
+        elif [ "$1" = "0" ]; then
+            echo "${Fyellow}0${plain}"
+        elif printf "%s" "$1" | grep -Eq '^[0-9]+$'; then
             echo "${green}$1${plain}"
+        else
+            echo "${gray}auto${plain}"
         fi
     }
 
@@ -25,6 +29,22 @@ orch_max_strategy_for_profile() {
     config_profile_max_strategy "$1"
 }
 
+profile_strategy_restart_notice() {
+    if [ -n "${ZAPRET2_INIT:-}" ] && [ -x "$ZAPRET2_INIT" ]; then
+        "$ZAPRET2_INIT" restart
+        echo -e "${green}zapret2 перезапущен для применения изменений config.${plain}"
+    else
+        echo -e "${yellow}Перезапустите zapret2, чтобы изменения config вступили в силу.${plain}"
+    fi
+}
+
+profile_strategy_restart_if_needed() {
+    if [ "$1" = "6" ]; then
+        profile_strategy_restart_notice
+    fi
+    return 0
+}
+
 orch_profile_try() {
     local profile="$1"
     local title="$2"
@@ -33,6 +53,7 @@ orch_profile_try() {
     local max_strat=""
     local start_strat=""
     local current_strat=""
+    local current_state=""
     local answer=""
     local first_proto="${proto_list%% *}"
     local -A prev_map
@@ -44,15 +65,29 @@ orch_profile_try() {
         return
     fi
 
-    current_strat="$(orch_locked_get "$profile" "$first_proto")"
-    if [ -z "$current_strat" ] || [ "$current_strat" -le 0 ]; then
+    current_state="$(profile_state_display "$profile" "$first_proto")"
+    current_strat="$current_state"
+    if [ "$current_strat" = "auto" ] || [ "$current_strat" = "0" ] || [ -z "$current_strat" ]; then
         current_strat=1
     fi
 
     echo "$title"
-    read -re -p "Введите номер стратегии (Enter - текущая $current_strat): " start_strat
+    echo "Текущее состояние: $current_state"
+    read -re -p "Введите номер стратегии (0 - отключить профиль, Enter - без изменений): " start_strat
     if [ -z "$start_strat" ]; then
-        start_strat="$current_strat"
+        echo "Без изменений."
+        return
+    fi
+    if [ "$start_strat" = "0" ]; then
+        if profile_state_set_and_apply "$profile" "$proto_list" "0" "$(get_config_file)"; then
+            echo "Профиль $profile выключен и сохранён как 0."
+            profile_strategy_restart_if_needed "$profile"
+        else
+            echo -e "${red}Не удалось выключить профиль $profile.${plain}"
+        fi
+        telemetry_notify
+        pause_enter
+        return
     fi
     if ! printf "%s" "$start_strat" | grep -Eq '^[0-9]+$'; then
         echo "Неверный номер стратегии. Начинаем с 1."
@@ -64,6 +99,7 @@ orch_profile_try() {
 
     for p in $proto_list; do
         prev_map["$p"]="$(orch_locked_get "$profile" "$p")"
+        [ "$current_state" = "0" ] && prev_map["$p"]="0"
     done
 
     for ((s=start_strat; s<=max_strat; s++)); do
@@ -92,7 +128,12 @@ orch_profile_try() {
 
         read -re -p "1 - сохранить, 0 - отмена, Enter - далее: " answer
         if [ "$answer" = "1" ]; then
-            echo "Стратегия $s сохранена для профиля $profile."
+            if profile_state_set_and_apply "$profile" "$proto_list" "$s" "$(get_config_file)"; then
+                echo "Стратегия $s сохранена для профиля $profile."
+                profile_strategy_restart_if_needed "$profile"
+            else
+                echo -e "${red}Не удалось сохранить стратегию $s для профиля $profile.${plain}"
+            fi
             telemetry_notify
             pause_enter
             return
@@ -104,6 +145,8 @@ orch_profile_try() {
     for p in $proto_list; do
         if [ -n "${prev_map[$p]}" ] && [ "${prev_map[$p]}" -gt 0 ]; then
             orch_locked_set "$profile" "$p" "${prev_map[$p]}"
+        elif [ "${prev_map[$p]}" = "0" ]; then
+            orch_locked_set "$profile" "$p" 0
         else
             orch_locked_clear "$profile" "$p"
         fi
@@ -113,27 +156,30 @@ orch_profile_try() {
 }
 
 get_orchestra_locks_info() {
-    local yt_tls="" gv_tls="" rkn_tls="" ds_tls="" yt_quic_udp="" voice_udp="" games_udp="" fb_http=""
+    local yt_tls="" gv_tls="" rkn_tls="" ds_tls="" yt_quic_udp="" voice_udp="" games_udp="" fb_tls="" fb_http=""
     local v=""
-    yt_tls="$(orch_locked_get 1 tls)"
-    gv_tls="$(orch_locked_get 2 tls)"
-    rkn_tls="$(orch_locked_get 3 tls)"
-    ds_tls="$(orch_locked_get 4 tls)"
-    yt_quic_udp="$(orch_locked_get 5 udp)"
-    voice_udp="$(orch_locked_get 6 udp)"
-    games_udp="$(orch_locked_get 7 udp)"
-    fb_http="$(orch_locked_get 9 http)"
+    yt_tls="$(profile_state_display 1 tls)"
+    gv_tls="$(profile_state_display 2 tls)"
+    rkn_tls="$(profile_state_display 3 tls)"
+    ds_tls="$(profile_state_display 4 tls)"
+    yt_quic_udp="$(profile_state_display 5 udp)"
+    voice_udp="$(profile_state_display 6 udp)"
+    games_udp="$(profile_state_display 7 udp)"
+    fb_tls="$(profile_state_display 8 tls)"
+    fb_http="$(profile_state_display 9 http)"
 
     fmt_status_num() {
-        v="${1:-0}"
-        if [ "$v" = "0" ]; then
+        v="${1:-auto}"
+        if [ "$v" = "auto" ]; then
+            printf "%b" "${gray}auto${plain}"
+        elif [ "$v" = "0" ]; then
             printf "%b" "${Fyellow}0${plain}"
         else
             printf "%b" "${Fcyan}${v}${plain}"
         fi
     }
 
-    printf "YT_TLS=%s GV_TLS=%s RKN_TLS=%s DS_TLS=%s YT_QUIC_UDP=%s VOICE_UDP=%s GAMES_UDP=%s FB_HTTP=%s" \
+    printf "YT_TLS=%s GV_TLS=%s RKN_TLS=%s DS_TLS=%s YT_QUIC_UDP=%s VOICE_UDP=%s GAMES_UDP=%s FB_TLS=%s FB_HTTP=%s" \
         "$(fmt_status_num "$yt_tls")" \
         "$(fmt_status_num "$gv_tls")" \
         "$(fmt_status_num "$rkn_tls")" \
@@ -141,6 +187,7 @@ get_orchestra_locks_info() {
         "$(fmt_status_num "$yt_quic_udp")" \
         "$(fmt_status_num "$voice_udp")" \
         "$(fmt_status_num "$games_udp")" \
+        "$(fmt_status_num "$fb_tls")" \
         "$(fmt_status_num "$fb_http")"
 }
 

--- a/orchestra/locked.lua
+++ b/orchestra/locked.lua
@@ -226,7 +226,10 @@ function circular_locked(ctx, desync)
       DLOG("circular_locked: fallback lock profile="..base_profile.." for host profile="..profile)
     end
   end
-  if locked and locked >= 1 and locked <= hrec.ctstrategy then
+  if locked == 0 then
+    DLOG("circular_locked: profile disabled by lock 0 profile="..profile)
+    return VERDICT_PASS
+  elseif locked and locked >= 1 and locked <= hrec.ctstrategy then
     hrec.nstrategy = locked
     DLOG("circular_locked: locked strategy "..hrec.nstrategy.." profile="..profile)
   else

--- a/tests/profile_lock_smoke.sh
+++ b/tests/profile_lock_smoke.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd -- "$SCRIPT_DIR/.." && pwd)"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+assert_contains() {
+  local text="$1"
+  local pattern="$2"
+  local message="$3"
+
+  printf '%s\n' "$text" | grep -Eq -- "$pattern" || fail "$message"
+}
+
+assert_not_contains() {
+  local text="$1"
+  local pattern="$2"
+  local message="$3"
+
+  ! printf '%s\n' "$text" | grep -Eq -- "$pattern" || fail "$message"
+}
+
+file_sha() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
+  else
+    cksum "$1" | awk '{print $1 ":" $2}'
+  fi
+}
+
+TMP_DIR="$(mktemp -d /tmp/zator-profile-lock.XXXXXX)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+ROOT="$TMP_DIR/zapret2"
+CFG="$ROOT/config"
+export ORCH_DIR="$ROOT/extra_strats/cache/orchestra"
+export ORCH_LOCK_FILE="$ORCH_DIR/locked.tsv"
+export PROFILE_STATE_FILE="$TMP_DIR/profile.lock"
+export ZAPRET2_INIT="$ROOT/init.d/sysv/zapret2"
+
+mkdir -p "$ORCH_DIR" "$ROOT/init.d/sysv/custom.d"
+sed "s#/opt/zapret2#$ROOT#g" "$REPO_DIR/config.default" > "$CFG"
+printf '#!/bin/sh\nexit 0\n' > "$ZAPRET2_INIT"
+chmod +x "$ZAPRET2_INIT"
+printf 'script\n' > "$ROOT/init.d/sysv/custom.d/50-stun4all"
+printf 'script\n' > "$ROOT/init.d/sysv/custom.d/50-discord-media"
+
+# shellcheck source=/dev/null
+source "$REPO_DIR/lib/config.sh"
+# shellcheck source=/dev/null
+source "$REPO_DIR/lib/orchestra_state.sh"
+
+for file in \
+  "$REPO_DIR/z2r.sh" \
+  "$REPO_DIR/lib/config.sh" \
+  "$REPO_DIR/lib/orchestra_state.sh" \
+  "$REPO_DIR/lib/strategies.sh" \
+  "$REPO_DIR/lib/submenus.sh" \
+  "$REPO_DIR/lib/actions.sh" \
+  "$REPO_DIR/webui/cgi-bin/_lib.sh"; do
+  bash -n "$file"
+done
+
+grep -q 'locked == 0' "$REPO_DIR/orchestra/locked.lua" || fail "locked.lua does not handle explicit 0 lock"
+grep -q 'profile disabled by lock 0' "$REPO_DIR/orchestra/locked.lua" || fail "locked.lua 0 path is not logged"
+
+[ "$(profile_state_get 3 tls)" = "auto" ] || fail "missing state must be auto"
+
+orch_locked_set 2 tls 5
+[ "$(profile_state_get 2 tls)" = "5" ] || fail "effective state must read existing orchestra lock"
+[ "$(profile_state_stored_get 2 tls)" = "auto" ] || fail "existing orchestra lock must not create persistent state"
+orch_locked_clear 2 tls
+
+profile_state_set 3 tls 0
+[ "$(profile_state_stored_get 3 tls)" = "0" ] || fail "RKN 0 was not stored"
+[ "$(profile_state_display 3 tls)" = "0" ] || fail "0 must be displayed as 0"
+grep -Eq '^3[[:space:]]+tls[[:space:]]+0$' "$PROFILE_STATE_FILE" || fail "RKN 0 row is missing"
+profile_apply_all "$CFG"
+[ "$(orch_locked_get 3 tls)" = "0" ] || fail "RKN 0 was not rehydrated into orchestra lock"
+[ "$(orch_locked_state_get 3 tls)" = "0" ] || fail "explicit 0 lock must be distinguishable from auto"
+
+sum_before="$(file_sha "$CFG")"
+profile_apply_all "$CFG"
+sum_after="$(file_sha "$CFG")"
+[ "$sum_before" = "$sum_after" ] || fail "profile_apply_all is not idempotent"
+
+profile_state_set 4 tls 2
+profile_apply_all "$CFG"
+[ "$(orch_locked_get 4 tls)" = "2" ] || fail "Discord TCP orchestra lock was not restored"
+
+profile_state_set 6 udp 0
+profile_apply_all "$CFG"
+[ "$(orch_locked_get 6 udp)" = "0" ] || fail "VOICE 0 was not rehydrated into orchestra lock"
+udp_ports_line="$(config_get_var "$CFG" NFQWS2_PORTS_UDP)"
+assert_not_contains "$udp_ports_line" '(^|,)50000-50099(,|$)' "VOICE ports are still in NFQWS2_PORTS_UDP"
+[ -f "$ROOT/init.d/sysv/custom.d.disabled/50-stun4all" ] || fail "50-stun4all was not disabled"
+[ -f "$ROOT/init.d/sysv/custom.d.disabled/50-discord-media" ] || fail "50-discord-media was not disabled"
+
+profile_state_set 6 udp 2
+profile_apply_all "$CFG"
+udp_ports_line="$(config_get_var "$CFG" NFQWS2_PORTS_UDP)"
+assert_contains "$udp_ports_line" '(^|,)50000-50099(,|$)' "VOICE ports were not restored"
+[ "$(orch_locked_get 6 udp)" = "2" ] || fail "VOICE orchestra lock was not restored"
+
+profile_state_set 8 tls 0
+profile_apply_all "$CFG"
+manual_lock="$ORCH_DIR/locked.manual.tsv"
+[ -f "$manual_lock" ] || fail "manual fallback lock file was not created"
+grep -Eq '^8[[:space:]]+tls[[:space:]]+0$' "$manual_lock" || fail "fallback TLS 0 was not written to locked.manual.tsv"
+
+profile_state_set_and_apply 3 "tls" auto "$CFG"
+[ "$(profile_state_stored_get 3 tls)" = "auto" ] || fail "RKN state was not cleared to auto"
+[ "$(orch_locked_state_get 3 tls)" = "auto" ] || fail "RKN orchestra lock was not cleared on auto"
+
+orch_locked_set 3 tls 1
+prev_lock="$(orch_locked_state_get 3 tls)"
+[ "$prev_lock" = "1" ] || fail "test setup failed to set RKN runtime lock"
+prev_lock="0"
+if [ "$prev_lock" = "0" ]; then
+  orch_locked_set 3 tls 0
+else
+  orch_locked_clear 3 tls
+fi
+[ "$(orch_locked_state_get 3 tls)" = "0" ] || fail "explicit 0 lock was not restored after cancel"
+
+sed "s#/opt/zapret2#$ROOT#g" "$REPO_DIR/config.default" > "$CFG"
+profile_apply_all "$CFG"
+[ "$(orch_locked_get 6 udp)" = "2" ] || fail "stored VOICE N was not rehydrated into orchestra lock"
+assert_contains "$(config_get_var "$CFG" NFQWS2_PORTS_UDP)" '(^|,)50000-50099(,|$)' "stored VOICE N did not restore voice ports on fresh config"
+grep -Eq '^8[[:space:]]+tls[[:space:]]+0$' "$manual_lock" || fail "stored fallback TLS 0 was not rehydrated"
+
+printf '5\tudp\t99\n' > "$PROFILE_STATE_FILE"
+profile_apply_all "$CFG" >/dev/null
+printf '5\tudp\tbad\n' > "$PROFILE_STATE_FILE"
+profile_apply_all "$CFG" >/dev/null
+
+saved_orch_lock_file="$ORCH_LOCK_FILE"
+broken_lock_parent="$TMP_DIR/locked-parent-is-file"
+printf 'not a directory\n' > "$broken_lock_parent"
+ORCH_LOCK_FILE="$broken_lock_parent/locked.tsv"
+printf '3\ttls\t0\n' > "$PROFILE_STATE_FILE"
+if profile_apply_all "$CFG" >/dev/null 2>&1; then
+  fail "profile_apply_all masked an orchestra lock write error"
+fi
+ORCH_LOCK_FILE="$saved_orch_lock_file"
+
+echo "profile_lock smoke ok"

--- a/webui/app.js
+++ b/webui/app.js
@@ -179,9 +179,9 @@ function renderStrategies() {
     const inlineCheck = node.querySelector('.inline-check');
     const stepButtons = node.querySelectorAll('.step-strategy');
 
-    input.min = '1';
+    input.min = '0';
     input.max = String(profile.max_strategy);
-    if (profile.current_lock && profile.current_lock !== '0') {
+    if (/^[0-9]+$/.test(String(profile.current_lock || ''))) {
       input.value = profile.current_lock;
     }
     if (state.strategyChecks[profile.profile]) {
@@ -193,7 +193,8 @@ function renderStrategies() {
         const step = Number(button.dataset.step || 0);
         const min = Number(input.min || 1);
         const max = Number(input.max || profile.max_strategy || min);
-        const current = Number(input.value || profile.current_lock || min);
+        const parsed = Number(input.value || profile.current_lock);
+        const current = Number.isFinite(parsed) ? parsed : min;
         const next = Math.min(max, Math.max(min, current + step));
         input.value = String(next);
         input.dispatchEvent(new Event('input', { bubbles: true }));
@@ -202,8 +203,9 @@ function renderStrategies() {
 
     form.addEventListener('submit', async (event) => {
       event.preventDefault();
-      const value = Number(input.value);
-      if (!value) {
+      const rawValue = input.value.trim();
+      const value = Number(rawValue);
+      if (!/^[0-9]+$/.test(rawValue) || value > Number(input.max || profile.max_strategy || 0)) {
         showBanner('Введите номер стратегии.', 'error');
         return;
       }
@@ -218,7 +220,7 @@ function renderStrategies() {
           state.strategyChecks[profile.profile] = payload?.check;
           await refreshAll();
         });
-        showBanner(`Стратегия ${value} сохранена для ${profile.label}.`);
+        showBanner(value === 0 ? `Профиль ${profile.label} выключен.` : `Стратегия ${value} сохранена для ${profile.label}.`);
       } catch (error) {
         showBanner(error.message, 'error');
       }

--- a/webui/cgi-bin/_lib.sh
+++ b/webui/cgi-bin/_lib.sh
@@ -109,7 +109,7 @@ profile_proto() {
 profile_json() {
   local id="$1" label="$2" desc="$3" proto current max
   proto="$(profile_proto "$id")"
-  current="$(orch_locked_get "$id" "$proto")"
+  current="$(profile_state_display "$id" "$proto")"
   max="$(orch_max_strategy_for_profile "$id")"
   printf '{"profile":%s,"label":"%s","description":"%s","current_lock":"%s","max_strategy":%s}' \
     "$id" "$(json_escape "$label")" "$(json_escape "$desc")" "$(json_escape "$current")" "${max:-0}"
@@ -146,7 +146,7 @@ service_zapret2() {
 }
 
 strategy_locks_status_text() {
-  if [ -s "$ORCH_DIR/locked.tsv" ] || [ -s "$ORCH_DIR/locked.manual.tsv" ]; then
+  if [ -s "$ORCH_DIR/locked.tsv" ] || [ -s "$ORCH_DIR/locked.manual.tsv" ] || [ -s "$(profile_state_file)" ]; then
     echo "Есть"
   else
     echo "Нет"
@@ -224,14 +224,20 @@ api_set_lock() {
   parse_params
   [[ "${PARAM_PROFILE:-}" =~ ^[1-7]$ ]] || send_error "400 Bad Request" "Некорректный профиль"
   [[ "${PARAM_STRATEGY:-}" =~ ^[0-9]+$ ]] || send_error "400 Bad Request" "Некорректная стратегия"
-  local max proto_list p check_json
+  local max proto_list check_json saved_state
   max="$(orch_max_strategy_for_profile "$PARAM_PROFILE")"
-  [ "${PARAM_STRATEGY}" -ge 1 ] && [ "${PARAM_STRATEGY}" -le "${max:-0}" ] || send_error "400 Bad Request" "Стратегия вне диапазона"
+  if [ "${PARAM_STRATEGY}" -ne 0 ]; then
+    [ "${PARAM_STRATEGY}" -ge 1 ] && [ "${PARAM_STRATEGY}" -le "${max:-0}" ] || send_error "400 Bad Request" "Стратегия вне диапазона"
+  fi
   proto_list="$(profile_proto_list "$PARAM_PROFILE")"
   [ -n "$proto_list" ] || send_error "400 Bad Request" "Не удалось определить протокол профиля"
-  for p in $proto_list; do
-    orch_locked_set "$PARAM_PROFILE" "$p" "$PARAM_STRATEGY"
-  done
+  if [ "${PARAM_STRATEGY}" -eq 0 ]; then
+    saved_state="0"
+  else
+    saved_state="$PARAM_STRATEGY"
+  fi
+  profile_state_set_and_apply "$PARAM_PROFILE" "$proto_list" "$saved_state" "$CONFIG_FILE" || send_error "500 Internal Server Error" "Не удалось сохранить состояние профиля"
+  [ "$PARAM_PROFILE" = "6" ] && service_zapret2 restart >/dev/null 2>&1 || true
   telemetry_notify
   check_json="$(profile_check_json "$PARAM_PROFILE")"
   send_json "200 OK" "{\"ok\":true,\"check\":$check_json}"
@@ -240,12 +246,11 @@ api_set_lock() {
 api_clear_lock() {
   parse_params
   [[ "${PARAM_PROFILE:-}" =~ ^[1-7]$ ]] || send_error "400 Bad Request" "Некорректный профиль"
-  local proto_list p
+  local proto_list
   proto_list="$(profile_proto_list "$PARAM_PROFILE")"
   [ -n "$proto_list" ] || send_error "400 Bad Request" "Не удалось определить протокол профиля"
-  for p in $proto_list; do
-    orch_locked_clear "$PARAM_PROFILE" "$p"
-  done
+  profile_state_set_and_apply "$PARAM_PROFILE" "$proto_list" "auto" "$CONFIG_FILE" || send_error "500 Internal Server Error" "Не удалось сбросить состояние профиля"
+  [ "$PARAM_PROFILE" = "6" ] && service_zapret2 restart >/dev/null 2>&1 || true
   telemetry_notify
   send_json "200 OK" "{\"ok\":true}"
 }

--- a/z2r.sh
+++ b/z2r.sh
@@ -1837,6 +1837,8 @@ if [[ "$OSystem" == "entware" ]]; then
  config_keenetic_set_wan_iface_all
 fi
 
+profile_apply_all /opt/zapret2/config.default
+
 #Для x-wrt
 if [[ "$release" == "x-wrt" ]]; then
 	sed -i 's/kmod-nft-nat kmod-nft-offload/kmod-nft-nat/' /opt/zapret2/common/installer.sh


### PR DESCRIPTION
## Что изменено

Добавлено сохраняемое состояние профилей стратегий, чтобы выбранное пользователем состояние не терялось после обновления или пересоздания `config` из `config.default`.

Теперь состояние читается так:

```text
auto - нет ручной фиксации, поведение как раньше
0    - профиль явно выключен
N    - профиль включён и закреплён на стратегии N
```

Состояние хранится отдельно от `/opt/zapret2`, поэтому не пропадает при сбросе конфига:

```text
/opt/etc/z2r/profile.lock
```

## Как это работает

Основное упрощение в том, что выключение профиля теперь обрабатывается в `locked.lua`.

Если в TSV lock-файле для профиля записан `0`, `locked.lua` возвращает `VERDICT_PASS` и не выполняет ни одну desync-стратегию для этого профиля. Поэтому для большинства профилей не нужно переписывать `config` и расставлять `--skip`.

Например:

```text
3	tls	0
6	udp	2
```

Первый профиль будет явно выключен, второй будет закреплён на стратегии `2`.

## Что делает shell-слой

Shell-код теперь в основном отвечает за сохранение и восстановление состояния:

- записывает `auto` как отсутствие строки;
- сохраняет `0` и `N` в persistent state;
- после reset/update заново восстанавливает `locked.tsv` и `locked.manual.tsv`;
- показывает в меню разные состояния: `auto`, `0`, `N`;
- даёт выставить `0` через CLI и WebUI.

Отдельный случай остался только для `VOICE_UDP=0`: кроме записи lock `0`, из `NFQWS2_PORTS_UDP` убираются voice-порты, чтобы лишний voice-трафик не уходил в NFQUEUE.

## Проверка

Добавлен smoke-test:

```bash
bash tests/profile_lock_smoke.sh
```

Он работает во временной директории `/tmp`, не пишет в `/opt` и проверяет:

- хранение `auto/0/N/clear`;
- восстановление lock-файлов после fresh config;
- поведение `locked.lua` для lock `0`;
- `VOICE_UDP=0` и удаление voice-портов;
- fallback lock через `locked.manual.tsv`;
- идемпотентность `profile_apply_all`.
