### PR TITLE
Обновлятор с закреплённым источником и SHA-кэшем

### DIFF
--- a/lib/orchestra_state.sh
+++ b/lib/orchestra_state.sh
@@ -59,6 +59,40 @@ profile_state_file() {
   printf '%s\n' "$PROFILE_STATE_FILE"
 }
 
+# Снимок runtime-lock файлов нужен перед пересозданием /opt/zapret2: ранние
+# установки хранили ручные стратегии только в locked.tsv, без profile.lock.
+# Поэтому при обновлении нельзя полагаться лишь на persistent state вне /opt.
+orch_runtime_state_snapshot() {
+  local source_dir="${1:-$ORCH_DIR}"
+  local snapshot_dir="$2"
+  local name tmp
+
+  [ -n "$snapshot_dir" ] || return 1
+  mkdir -p "$snapshot_dir" || return 1
+  for name in locked.tsv locked.manual.tsv auto_locked.tsv; do
+    if [ -f "$source_dir/$name" ]; then
+      tmp="$snapshot_dir/$name.tmp.$$"
+      cp "$source_dir/$name" "$tmp" && mv -f "$tmp" "$snapshot_dir/$name" || return 1
+    else
+      rm -f "$snapshot_dir/$name"
+    fi
+  done
+}
+
+orch_runtime_state_restore() {
+  local target_dir="${1:-$ORCH_DIR}"
+  local snapshot_dir="$2"
+  local name tmp
+
+  [ -d "$snapshot_dir" ] || return 0
+  mkdir -p "$target_dir" || return 1
+  for name in locked.tsv locked.manual.tsv auto_locked.tsv; do
+    [ -f "$snapshot_dir/$name" ] || continue
+    tmp="$target_dir/$name.tmp.$$"
+    cp "$snapshot_dir/$name" "$tmp" && mv -f "$tmp" "$target_dir/$name" || return 1
+  done
+}
+
 profile_state_normalize() {
   case "$1" in
     ""|"auto")

--- a/lib/updater.sh
+++ b/lib/updater.sh
@@ -1,0 +1,253 @@
+#!/bin/bash
+
+# Runtime-часть updater. Bootstrap-функции чтения source state и разрешения
+# ref находятся в z2r.sh: они нужны до того, как этот модуль станет доступен.
+
+Z2R_RUNTIME_ROOT="${Z2R_RUNTIME_ROOT:-/opt}"
+
+z2r_sha256_file() {
+  local file="$1"
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$file" | awk '{print $1}'
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$file" | awk '{print $1}'
+  elif command -v openssl >/dev/null 2>&1; then
+    openssl dgst -sha256 "$file" | awk '{print $NF}'
+  else
+    return 127
+  fi
+}
+
+z2r_source_cache_namespace() {
+  local identity
+  identity="${Z2R_SOURCE_REPOSITORY:-${Z2R_SOURCE_RAW_ROOT:-$Z2R_SOURCE_RAW_BASE}}"
+  printf '%s' "$identity" | sed 's/[^A-Za-z0-9._-]/_/g'
+}
+
+z2r_source_validate_rel_path() {
+  local rel="$1"
+  case "$rel" in ''|/*|*'..'*|*[!A-Za-z0-9._/-]*) return 1 ;; esac
+}
+
+z2r_source_cache_path() {
+  local rel="$1" namespace safe_rel
+  z2r_source_validate_rel_path "$rel" || return 1
+  [ -n "${Z2R_SOURCE_RESOLVED_COMMIT:-}" ] || return 1
+  namespace="$(z2r_source_cache_namespace)" || return 1
+  safe_rel="$(printf '%s' "$rel" | tr '/' '@')"
+  printf '%s/update-state/%s/%s/%s\n' \
+    "$Z2R_UPDATE_DIR" "$namespace" "$Z2R_SOURCE_RESOLVED_COMMIT" "$safe_rel"
+}
+
+z2r_source_cache_restore() {
+  local rel="$1" dest="$2" cache checksum expected actual
+  cache="$(z2r_source_cache_path "$rel")" || return 1
+  checksum="${cache}.sha256"
+  [ -s "$cache" ] && [ -s "$checksum" ] || return 1
+  expected="$(sed -n '1p' "$checksum")"
+  actual="$(z2r_sha256_file "$cache" 2>/dev/null || true)"
+  if [ "$actual" != "$expected" ]; then
+    rm -f "$cache" "$checksum"
+    return 1
+  fi
+  cp -f "$cache" "$dest"
+}
+
+z2r_source_cache_store() {
+  local rel="$1" source_file="$2" cache checksum tmp checksum_tmp sha
+  cache="$(z2r_source_cache_path "$rel")" || return 1
+  checksum="${cache}.sha256"
+  tmp="${cache}.tmp.$$"
+  checksum_tmp="${checksum}.tmp.$$"
+  mkdir -p "$(dirname "$cache")" || return 1
+  cp -f "$source_file" "$tmp" || { rm -f "$tmp"; return 1; }
+  sha="$(z2r_sha256_file "$tmp")" || { rm -f "$tmp"; return 1; }
+  printf '%s\n' "$sha" > "$checksum_tmp" || { rm -f "$tmp" "$checksum_tmp"; return 1; }
+  mv -f "$tmp" "$cache" || { rm -f "$tmp" "$checksum_tmp"; return 1; }
+  mv -f "$checksum_tmp" "$checksum"
+}
+
+z2r_source_track_begin() {
+  mkdir -p "$Z2R_UPDATE_DIR" || return 1
+  Z2R_SOURCE_TRACK_FILE="$Z2R_UPDATE_DIR/.deployed-files.tmp.$$"
+  : > "$Z2R_SOURCE_TRACK_FILE"
+  export Z2R_SOURCE_TRACK_FILE
+}
+
+z2r_source_track_file() {
+  local dest="$1" rel="$2" deployed_sha remote_sha cache tmp
+  [ -n "${Z2R_SOURCE_TRACK_FILE:-}" ] || return 0
+  z2r_source_validate_rel_path "$rel" || return 1
+  case "$dest" in "$Z2R_RUNTIME_ROOT"/*) ;; *) return 0 ;; esac
+  deployed_sha="$(z2r_sha256_file "$dest")" || return 1
+  cache="$(z2r_source_cache_path "$rel" 2>/dev/null || true)"
+  remote_sha="$(sed -n '1p' "${cache}.sha256" 2>/dev/null || true)"
+  [ -n "$remote_sha" ] || remote_sha="$deployed_sha"
+  tmp="${Z2R_SOURCE_TRACK_FILE}.next"
+  awk -F '\t' -v path="$dest" '$1 != path { print }' "$Z2R_SOURCE_TRACK_FILE" > "$tmp" || return 1
+  printf '%s\t%s\t%s\t%s\n' "$dest" "$rel" "$remote_sha" "$deployed_sha" >> "$tmp" || return 1
+  mv -f "$tmp" "$Z2R_SOURCE_TRACK_FILE"
+}
+
+z2r_source_track_finish() {
+  local manifest files tmp old_umask installed_at
+  [ -n "${Z2R_SOURCE_TRACK_FILE:-}" ] || return 0
+  [ -f "$Z2R_SOURCE_TRACK_FILE" ] || return 1
+  manifest="$Z2R_UPDATE_DIR/deployed.manifest"
+  files="$Z2R_UPDATE_DIR/deployed.files"
+  tmp="${manifest}.tmp.$$"
+  installed_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  old_umask="$(umask)"
+  umask 077
+  {
+    printf 'repository=%s\n' "${Z2R_SOURCE_REPOSITORY:-}"
+    printf 'raw_base=%s\n' "${Z2R_SOURCE_RAW_ROOT:-$Z2R_SOURCE_RAW_BASE}"
+    printf 'requested_ref=%s\n' "$Z2R_SOURCE_REF"
+    printf 'resolved_commit=%s\n' "$Z2R_SOURCE_RESOLVED_COMMIT"
+    printf 'installed_at=%s\n' "$installed_at"
+  } > "$tmp" || { umask "$old_umask"; rm -f "$tmp"; return 1; }
+  umask "$old_umask"
+  mv -f "$tmp" "$manifest" || return 1
+  mv -f "$Z2R_SOURCE_TRACK_FILE" "$files" || return 1
+  unset Z2R_SOURCE_TRACK_FILE
+}
+
+z2r_source_manifest_value() {
+  local key="$1" manifest="$Z2R_UPDATE_DIR/deployed.manifest"
+  [ -f "$manifest" ] || return 1
+  sed -n "s/^${key}=//p" "$manifest" | head -n 1
+}
+
+z2r_source_local_change_count() {
+  local files="$Z2R_UPDATE_DIR/deployed.files" dest rel remote_sha deployed_sha actual count=0
+  [ -f "$files" ] || { printf 'unknown\n'; return 0; }
+  while IFS=$'\t' read -r dest rel remote_sha deployed_sha; do
+    [ -n "$dest" ] || continue
+    if [ ! -f "$dest" ]; then
+      count=$((count + 1))
+      continue
+    fi
+    actual="$(z2r_sha256_file "$dest" 2>/dev/null || true)"
+    [ "$actual" = "$deployed_sha" ] || count=$((count + 1))
+  done < "$files"
+  printf '%s\n' "$count"
+}
+
+z2r_source_status_line() {
+  local installed changes source
+  source="${Z2R_SOURCE_REPOSITORY:-$Z2R_SOURCE_RAW_BASE}"
+  installed="$(z2r_source_manifest_value resolved_commit 2>/dev/null || true)"
+  changes="$(z2r_source_local_change_count)"
+  [ -n "$installed" ] || installed="неизвестно"
+  case "$changes" in
+    0) changes="чисто" ;;
+    unknown) changes="неизвестно" ;;
+    *) changes="изменено: $changes" ;;
+  esac
+  printf '%s @ %s; установлено: %.12s; runtime: %s' \
+    "$source" "$Z2R_SOURCE_REF" "$installed" "$changes"
+}
+
+z2r_source_show() {
+  local installed installed_at changes source
+  source="${Z2R_SOURCE_REPOSITORY:-$Z2R_SOURCE_RAW_BASE}"
+  installed="$(z2r_source_manifest_value resolved_commit 2>/dev/null || true)"
+  installed_at="$(z2r_source_manifest_value installed_at 2>/dev/null || true)"
+  changes="$(z2r_source_local_change_count)"
+  echo "Настроенный источник: $source"
+  echo "Запрошенный ref: $Z2R_SOURCE_REF"
+  echo "Источник настроек: $Z2R_SOURCE_CONFIG_ORIGIN"
+  echo "Установленный commit: ${installed:-нет manifest}"
+  echo "Дата установки: ${installed_at:-неизвестно}"
+  case "$changes" in
+    0) echo "Локальные изменения runtime: нет" ;;
+    unknown) echo "Локальные изменения runtime: неизвестно (нет manifest)" ;;
+    *) echo "Локальные изменения runtime: да ($changes файлов)" ;;
+  esac
+}
+
+z2r_source_set() {
+  local repository="$1" ref="$2"
+  z2r_source_validate_repository "$repository" || {
+    echo "Repository должен иметь вид owner/name." >&2
+    return 1
+  }
+  z2r_source_validate_ref "$ref" || {
+    echo "Некорректный installation ref." >&2
+    return 1
+  }
+  z2r_source_write_config "$repository" "$ref"
+  echo "Источник сохранён. Обновление начнётся при следующей подтверждённой установке/обновлении."
+}
+
+z2r_source_pin() {
+  local commit="${1:-}"
+  if [ -z "$commit" ]; then
+    z2r_source_prepare || return 1
+    commit="$Z2R_SOURCE_RESOLVED_COMMIT"
+  fi
+  z2r_source_validate_sha "$commit" || {
+    echo "Commit должен быть полным 40-символьным SHA." >&2
+    return 1
+  }
+  z2r_source_write_config "$Z2R_SOURCE_RAW_BASE" "$commit"
+  echo "Источник закреплён на commit $commit."
+}
+
+z2r_source_reconcile_files() {
+  local files="$Z2R_UPDATE_DIR/deployed.files" dest rel remote_sha deployed_sha
+  [ -f "$files" ] || {
+    echo "Нет списка установленных файлов: выполните полное обновление zapret2." >&2
+    return 1
+  }
+  z2r_source_track_begin || return 1
+  while IFS=$'\t' read -r dest rel remote_sha deployed_sha; do
+    [ -n "$dest" ] || continue
+    case "$dest" in "$Z2R_RUNTIME_ROOT"/*) ;; *) continue ;; esac
+    z2r_source_validate_rel_path "$rel" || return 1
+    z2r_download_project_file "$dest" "$rel" || return 1
+  done < "$files"
+  z2r_source_track_finish
+}
+
+z2r_source_reset() {
+  local old_namespace old_state
+  old_namespace="$(z2r_source_cache_namespace)"
+  old_state="$Z2R_UPDATE_DIR/update-state/$old_namespace"
+  z2r_source_write_config "$Z2R_DEFAULT_SOURCE_RAW_BASE" "$Z2R_DEFAULT_SOURCE_REF" || return 1
+  if [ -n "$old_namespace" ] && [ -d "$old_state" ]; then
+    rm -rf "$old_state"
+  fi
+  z2r_source_load_config || return 1
+  z2r_source_prepare || return 1
+  z2r_source_reconcile_files
+  echo "Источник сброшен на штатный и отслеживаемые файлы синхронизированы."
+}
+
+z2r_source_command() {
+  local action="${1:-show}"
+  shift || true
+  case "$action" in
+    show) z2r_source_show ;;
+    set)
+      [ "${1:-}" = "custom" ] && shift
+      [ "$#" -eq 2 ] || {
+        echo "Использование: z2r source set owner/repository branch|tag|sha" >&2
+        return 1
+      }
+      z2r_source_set "$1" "$2"
+      ;;
+    pin)
+      [ "$#" -le 1 ] || { echo "Использование: z2r source pin [commit-sha]" >&2; return 1; }
+      z2r_source_pin "${1:-}"
+      ;;
+    reset)
+      [ "$#" -eq 0 ] || { echo "Использование: z2r source reset" >&2; return 1; }
+      z2r_source_reset
+      ;;
+    *)
+      echo "Использование: z2r source {show|set|pin|reset}" >&2
+      return 1
+      ;;
+  esac
+}

--- a/tests/profile_lock_smoke.sh
+++ b/tests/profile_lock_smoke.sh
@@ -162,4 +162,16 @@ if profile_apply_all "$CFG" >/dev/null 2>&1; then
 fi
 ORCH_LOCK_FILE="$saved_orch_lock_file"
 
+snapshot_dir="$TMP_DIR/orchestra-snapshot"
+printf '1\ttls\t28\n2\ttls\t16\n' > "$ORCH_DIR/locked.tsv"
+printf '8\ttls\t3\n' > "$ORCH_DIR/locked.manual.tsv"
+orch_runtime_state_snapshot "$ORCH_DIR" "$snapshot_dir"
+rm -f "$ORCH_DIR/locked.tsv" "$ORCH_DIR/locked.manual.tsv"
+orch_runtime_state_restore "$ORCH_DIR" "$snapshot_dir"
+[ "$(orch_locked_get 1 tls)" = "28" ] || fail "runtime YT lock was not restored after update"
+[ "$(orch_locked_get 2 tls)" = "16" ] || fail "runtime GoogleVideo lock was not restored after update"
+ORCH_LOCK_FILE="$ORCH_DIR/locked.manual.tsv"
+[ "$(orch_locked_get 8 tls)" = "3" ] || fail "runtime fallback lock was not restored after update"
+ORCH_LOCK_FILE="$saved_orch_lock_file"
+
 echo "profile_lock smoke ok"

--- a/tests/updater_cli_smoke.sh
+++ b/tests/updater_cli_smoke.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+set -e
+
+REPO_DIR="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+TEST_DIR="$(mktemp -d /tmp/z2r_updater_cli.XXXXXX)"
+trap 'rm -rf "$TEST_DIR"' EXIT
+
+RUNTIME_DIR="$TEST_DIR/runtime"
+STATE_DIR="$TEST_DIR/state"
+mkdir -p "$RUNTIME_DIR/zapret2/z2r_lib"
+cp "$REPO_DIR/z2r.sh" "$RUNTIME_DIR/z2r.sh"
+cp "$REPO_DIR/lib/"*.sh "$RUNTIME_DIR/zapret2/z2r_lib/"
+
+run_z2r() {
+  Z2R_DISABLE_SELF_REFRESH=1 \
+  Z2R_UPDATE_DIR="$STATE_DIR" \
+  Z2R_UPDATE_CONFIG="$STATE_DIR/update.conf" \
+  bash "$RUNTIME_DIR/z2r.sh" "$@"
+}
+
+run_z2r source set Sehat1137/zator zator > "$TEST_DIR/set.out"
+grep -F 'Z2R_PROJECT_RAW_BASE="Sehat1137/zator"' "$STATE_DIR/update.conf" >/dev/null
+grep -F 'Z2R_BRANCH="zator"' "$STATE_DIR/update.conf" >/dev/null
+
+commit="0123456789abcdef0123456789abcdef01234567"
+run_z2r source pin "$commit" > "$TEST_DIR/pin.out"
+grep -F "Z2R_BRANCH=\"$commit\"" "$STATE_DIR/update.conf" >/dev/null
+
+run_z2r source show > "$TEST_DIR/show.out"
+grep -F 'Настроенный источник: Sehat1137/zator' "$TEST_DIR/show.out" >/dev/null
+grep -F "Запрошенный ref: $commit" "$TEST_DIR/show.out" >/dev/null
+
+echo "updater cli smoke ok"

--- a/tests/updater_source_config_smoke.sh
+++ b/tests/updater_source_config_smoke.sh
@@ -1,0 +1,212 @@
+#!/bin/bash
+
+set -e
+
+REPO_DIR="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+TEST_DIR="$(mktemp -d /tmp/z2r_source_config.XXXXXX)"
+trap 'rm -rf "$TEST_DIR"' EXIT
+
+PREFIX="$TEST_DIR/z2r_prefix.sh"
+awk '/^#___Проверка на наличие необходимых библиотек___#$/ { exit } { print }' \
+  "$REPO_DIR/z2r.sh" > "$PREFIX"
+
+unset Z2R_PROJECT_RAW_BASE Z2R_BRANCH Z2R_REPOSITORY Z2R_COMMIT
+Z2R_UPDATE_DIR="$TEST_DIR/state"
+Z2R_UPDATE_CONFIG="$Z2R_UPDATE_DIR/update.conf"
+export Z2R_UPDATE_DIR Z2R_UPDATE_CONFIG
+
+# shellcheck disable=SC1090
+source "$PREFIX"
+Z2R_RUNTIME_ROOT="$TEST_DIR/runtime"
+# shellcheck disable=SC1090
+source "$REPO_DIR/lib/updater.sh"
+
+# Все runtime-библиотеки обязаны быть в preflight и в развёртывании. Иначе
+# после удаления /opt/zapret2 следующий запуск launcher попадёт в рекурсию.
+grep -F 'for rel in "${Z2R_RUNTIME_LIBRARIES[@]}"; do' "$REPO_DIR/z2r.sh" >/dev/null
+grep -F 'project_files+=("lib/$rel")' "$REPO_DIR/z2r.sh" >/dev/null
+grep -F 'for lib in "${Z2R_RUNTIME_LIBRARIES[@]}"; do' "$REPO_DIR/z2r.sh" >/dev/null
+grep -F 'z2r_download_project_file "/opt/zapret2/z2r_lib/$lib" "lib/$lib"' "$REPO_DIR/z2r.sh" >/dev/null
+grep -F 'z2r_download_project_file "$ORCH_LUA_LOCKED" "orchestra/locked.lua"' "$REPO_DIR/z2r.sh" >/dev/null
+grep -F 'z2r_download_project_file "$RST_GUARD_LUA" "lua/rst-guard.lua"' "$REPO_DIR/z2r.sh" >/dev/null
+
+assert_eq() {
+  local actual="$1" expected="$2" message="$3"
+  if [ "$actual" != "$expected" ]; then
+    echo "FAIL: $message: expected '$expected', got '$actual'" >&2
+    exit 1
+  fi
+}
+
+assert_file_contains() {
+  local needle="$1" file="$2"
+  grep -F -- "$needle" "$file" >/dev/null || {
+    echo "FAIL: '$needle' not found in $file" >&2
+    exit 1
+  }
+}
+
+mkdir -p "$Z2R_UPDATE_DIR"
+cat > "$Z2R_UPDATE_CONFIG" <<'EOF'
+# comments and surrounding whitespace are accepted
+Z2R_PROJECT_RAW_BASE = "Sehat1137/zator"
+Z2R_BRANCH='feature/test'
+EOF
+z2r_source_load_config
+assert_eq "$Z2R_SOURCE_RAW_BASE" "Sehat1137/zator" "repository shorthand"
+assert_eq "$Z2R_SOURCE_REF" "feature/test" "quoted installation ref"
+assert_eq "$Z2R_SOURCE_CONFIG_ORIGIN" "config" "config origin"
+
+cat > "$Z2R_UPDATE_CONFIG" <<'EOF'
+Z2R_REPOSITORY="Sehat1137/zator"
+Z2R_COMMIT="0123456789abcdef0123456789abcdef01234567"
+EOF
+z2r_source_load_config
+assert_eq "$Z2R_SOURCE_RAW_BASE" "https://raw.githubusercontent.com/Sehat1137/zator" "repository alias"
+assert_eq "$Z2R_SOURCE_REF" "0123456789abcdef0123456789abcdef01234567" "commit alias"
+
+Z2R_ENV_SOURCE_REF="env/test"
+z2r_source_load_config
+assert_eq "$Z2R_SOURCE_REF" "env/test" "environment override"
+assert_eq "$Z2R_SOURCE_CONFIG_ORIGIN" "environment" "environment origin"
+unset Z2R_ENV_SOURCE_REF
+
+marker="$TEST_DIR/should-not-exist"
+cat > "$Z2R_UPDATE_CONFIG" <<EOF
+Z2R_BRANCH="\$(touch $marker)"
+EOF
+if z2r_source_load_config; then
+  echo "FAIL: command-like value was accepted" >&2
+  exit 1
+fi
+[ ! -e "$marker" ] || {
+  echo "FAIL: update.conf value was executed" >&2
+  exit 1
+}
+
+cat > "$Z2R_UPDATE_CONFIG" <<'EOF'
+Z2R_UNKNOWN="value"
+EOF
+if z2r_source_load_config; then
+  echo "FAIL: unknown key was accepted" >&2
+  exit 1
+fi
+
+z2r_source_write_config "Sehat1137/zator" "zator"
+assert_file_contains 'Z2R_PROJECT_RAW_BASE="Sehat1137/zator"' "$Z2R_UPDATE_CONFIG"
+assert_file_contains 'Z2R_BRANCH="zator"' "$Z2R_UPDATE_CONFIG"
+
+if z2r_source_write_config "Sehat1137/zator" "bad ref"; then
+  echo "FAIL: invalid ref was written" >&2
+  exit 1
+fi
+
+cat > "$Z2R_UPDATE_CONFIG" <<'EOF'
+Z2R_PROJECT_RAW_BASE="https://raw.githubusercontent.com/Sehat1137/zator/feature/test"
+EOF
+z2r_source_load_config
+assert_eq "$Z2R_SOURCE_RAW_BASE" "https://raw.githubusercontent.com/Sehat1137/zator" "legacy raw root"
+assert_eq "$Z2R_SOURCE_REF" "feature/test" "legacy raw ref"
+
+mock_commit="0123456789abcdef0123456789abcdef01234567"
+z2r_fetch_url_stdout() {
+  printf '{"sha":"%s"}\n' "$mock_commit"
+}
+z2r_source_prepare
+assert_eq "$Z2R_SOURCE_REPOSITORY" "Sehat1137/zator" "resolved repository"
+assert_eq "$Z2R_SOURCE_RESOLVED_COMMIT" "$mock_commit" "resolved commit"
+assert_eq "$(z2r_source_raw_url 'lib/updater.sh')" \
+  "https://raw.githubusercontent.com/Sehat1137/zator/$mock_commit/lib/updater.sh" \
+  "commit-pinned raw URL"
+
+fetch_calls="$TEST_DIR/fetch.calls"
+z2r_fetch_url_to_file() {
+  printf '%s\n' "$2" >> "$fetch_calls"
+  return 1
+}
+if z2r_download_project_file "$TEST_DIR/downloaded" "lists/test.txt"; then
+  echo "FAIL: mocked strict download unexpectedly succeeded" >&2
+  exit 1
+fi
+assert_eq "$(wc -l < "$fetch_calls" | tr -d ' ')" "1" "strict download request count"
+assert_eq "$(cat "$fetch_calls")" \
+  "https://raw.githubusercontent.com/Sehat1137/zator/$mock_commit/lists/test.txt" \
+  "strict download URL"
+
+payload="$TEST_DIR/payload"
+printf 'cached payload\n' > "$payload"
+z2r_source_cache_store "lists/test.txt" "$payload"
+z2r_source_cache_restore "lists/test.txt" "$TEST_DIR/restored"
+assert_eq "$(cat "$TEST_DIR/restored")" "cached payload" "source-scoped cache"
+cache_path="$(z2r_source_cache_path "lists/test.txt")"
+printf 'corrupted cache\n' > "$cache_path"
+if z2r_source_cache_restore "lists/test.txt" "$TEST_DIR/corrupted-restored"; then
+  echo "FAIL: corrupted cache was accepted" >&2
+  exit 1
+fi
+
+runtime_file="$Z2R_RUNTIME_ROOT/zapret2/lists/test.txt"
+mkdir -p "$(dirname "$runtime_file")"
+cp "$payload" "$runtime_file"
+z2r_source_track_begin
+z2r_source_track_file "$runtime_file" "lists/test.txt"
+z2r_source_track_finish
+assert_eq "$(z2r_source_manifest_value resolved_commit)" "$mock_commit" "deployed manifest commit"
+assert_eq "$(z2r_source_local_change_count)" "0" "clean deployed runtime"
+printf 'manually changed\n' > "$runtime_file"
+assert_eq "$(z2r_source_local_change_count)" "1" "manual runtime change"
+
+z2r_fetch_url_to_file() {
+  printf 'canonical payload\n' > "$1"
+}
+z2r_source_reset
+assert_eq "$(cat "$runtime_file")" "canonical payload" "source reset reconciliation"
+assert_file_contains 'Z2R_PROJECT_RAW_BASE="https://raw.githubusercontent.com/AloofLibra/zator"' "$Z2R_UPDATE_CONFIG"
+assert_file_contains 'Z2R_BRANCH="zator"' "$Z2R_UPDATE_CONFIG"
+
+persistent_command="$TEST_DIR/bin/z2r"
+persistent_runtime="$TEST_DIR/runtime-launcher.sh"
+mkdir -p "$(dirname "$persistent_command")"
+printf '#!/bin/sh\necho legacy\n' > "$persistent_command"
+printf '#!/bin/bash\nexit 0\n' > "$persistent_runtime"
+chmod 755 "$persistent_command" "$persistent_runtime"
+Z2R_COMMAND_LAUNCHER="$persistent_command"
+Z2R_RUNTIME_LAUNCHER="$persistent_runtime"
+z2r_install_persistent_launcher
+assert_file_contains '# z2r persistent launcher' "$persistent_command"
+assert_file_contains "$(command -v bash)" "$persistent_command"
+assert_file_contains "$persistent_runtime" "$persistent_command"
+assert_file_contains 'echo legacy' "$Z2R_UPDATE_DIR/legacy-bootstrap.z2r"
+unset Z2R_COMMAND_LAUNCHER Z2R_RUNTIME_LAUNCHER
+
+launcher="$TEST_DIR/launcher.sh"
+refresh_payload="$TEST_DIR/launcher.new"
+refresh_marker="$TEST_DIR/refreshed"
+cat > "$launcher" <<'EOF'
+#!/bin/bash
+exit 0
+EOF
+cat > "$refresh_payload" <<EOF
+#!/bin/bash
+printf '%s' "\$Z2R_SELF_REFRESHED" > "$refresh_marker"
+EOF
+chmod 755 "$launcher" "$refresh_payload"
+launcher_link="$TEST_DIR/z2r"
+ln -s "$launcher" "$launcher_link"
+assert_eq "$(z2r_launcher_path "$launcher_link")" "$launcher" "launcher symlink resolution"
+z2r_fetch_url_to_file() {
+  cp "$refresh_payload" "$1"
+}
+(
+  Z2R_LAUNCHER_PATH="$launcher"
+  Z2R_SELF_REFRESH_ROOT="$TEST_DIR"
+  Z2R_SELF_REFRESHED=0
+  z2r_bootstrap_refresh_launcher
+)
+assert_eq "$(cat "$refresh_marker")" "1" "self-refresh exec guard"
+cmp -s "$launcher" "$refresh_payload" || {
+  echo "FAIL: launcher was not atomically replaced" >&2
+  exit 1
+}
+
+echo "updater source config smoke ok"

--- a/z2r.sh
+++ b/z2r.sh
@@ -29,6 +29,183 @@ Bblue='\033[44m'
 Bpink='\033[45m'
 Bcyan='\033[46m'
 
+# Optional updater state. На первом этапе эти значения только описывают
+# выбранный источник; существующий legacy URL flow ниже не меняется.
+Z2R_DEFAULT_SOURCE_RAW_BASE="https://raw.githubusercontent.com/AloofLibra/zator"
+Z2R_DEFAULT_SOURCE_REF="zator"
+Z2R_UPDATE_DIR="${Z2R_UPDATE_DIR:-/opt/etc/z2r}"
+Z2R_UPDATE_CONFIG="${Z2R_UPDATE_CONFIG:-$Z2R_UPDATE_DIR/update.conf}"
+Z2R_ORCHESTRA_SNAPSHOT_DIR="${Z2R_ORCHESTRA_SNAPSHOT_DIR:-$Z2R_UPDATE_DIR/orchestra-runtime}"
+Z2R_ENV_SOURCE_RAW_BASE="${Z2R_PROJECT_RAW_BASE-}"
+Z2R_ENV_SOURCE_REF="${Z2R_BRANCH-}"
+Z2R_ENV_SOURCE_REPOSITORY="${Z2R_REPOSITORY-}"
+Z2R_ENV_SOURCE_COMMIT="${Z2R_COMMIT-}"
+
+# z2r.sh выполняется из /opt, а рабочие функции — из runtime-каталога.
+# Держим список в одном месте: он нужен и для preflight перед удалением
+# старого runtime, и для его последующего развёртывания.
+Z2R_RUNTIME_LIBRARIES=(
+  ui.sh provider.sh telemetry.sh recommendations.sh netcheck.sh premium.sh
+  strategies.sh submenus.sh actions.sh config.sh orchestra_state.sh updater.sh
+)
+
+z2r_source_trim() {
+  local value="$1"
+  value="${value#"${value%%[![:space:]]*}"}"
+  value="${value%"${value##*[![:space:]]}"}"
+  printf '%s' "$value"
+}
+
+z2r_source_validate_repository() {
+  local repository="$1" owner name
+  case "$repository" in */*) ;; *) return 1 ;; esac
+  owner="${repository%%/*}"
+  name="${repository#*/}"
+  [ -n "$owner" ] && [ -n "$name" ] || return 1
+  [ "$repository" = "$owner/$name" ] || return 1
+  case "$owner$name" in *[!A-Za-z0-9_.-]*) return 1 ;; esac
+}
+
+z2r_source_validate_ref() {
+  local ref="$1"
+  [ -n "$ref" ] || return 1
+  case "$ref" in
+    [.-]*|[.-]|*/|/*|*//*) return 1 ;;
+    *[!A-Za-z0-9._/-]*) return 1 ;;
+    *..*|*@\{*|*'/./'*|*'/../'*|./*|../*|*/.|*/..) return 1 ;;
+  esac
+}
+
+z2r_source_validate_sha() {
+  [ "${#1}" -eq 40 ] || return 1
+  case "$1" in *[!A-Fa-f0-9]*) return 1 ;; esac
+}
+
+z2r_source_validate_base() {
+  local base="$1"
+  if z2r_source_validate_repository "$base" 2>/dev/null; then
+    return 0
+  fi
+  case "$base" in
+    *[[:space:]]*|*\;*|*\&*|*\|*|*\`*|*\$*|*\(*|*\)*|*\<*|*\>*) return 1 ;;
+    [A-Za-z][A-Za-z0-9+.-]*://*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+z2r_source_config_error() {
+  echo "Ошибка в $Z2R_UPDATE_CONFIG: $1" >&2
+  return 1
+}
+
+# Читает update.conf как данные. Файл намеренно не source-ится и не eval-ится.
+# Z2R_REPOSITORY/Z2R_COMMIT принимаются как совместимые aliases из раннего
+# формата proposal, но canonical запись использует raw base + installation ref.
+z2r_source_load_config() {
+  local raw_base="$Z2R_DEFAULT_SOURCE_RAW_BASE"
+  local ref="$Z2R_DEFAULT_SOURCE_REF"
+  local repository="" commit="" line key value legacy_path config_present=0
+
+  if [ -f "$Z2R_UPDATE_CONFIG" ]; then
+    config_present=1
+    while IFS= read -r line || [ -n "$line" ]; do
+      line="$(z2r_source_trim "$line")"
+      [ -z "$line" ] && continue
+      case "$line" in \#*) continue ;; esac
+      case "$line" in *=*) ;; *) z2r_source_config_error "ожидался KEY=VALUE"; return 1 ;; esac
+      key="$(z2r_source_trim "${line%%=*}")"
+      value="$(z2r_source_trim "${line#*=}")"
+      case "$key" in
+        Z2R_PROJECT_RAW_BASE|Z2R_BRANCH|Z2R_REPOSITORY|Z2R_COMMIT) ;;
+        *) z2r_source_config_error "неизвестный ключ $key"; return 1 ;;
+      esac
+      case "$value" in
+        \"*\") value="${value#\"}"; value="${value%\"}" ;;
+        \'*\') value="${value#\'}"; value="${value%\'}" ;;
+        *[[:space:]]*|*\"*|*\'*|*\\*|*\$*|*\`*|*\;*|*\(*|*\)*|*\&*|*\|*)
+          z2r_source_config_error "небезопасное значение для $key"; return 1 ;;
+      esac
+      case "$key" in
+        Z2R_PROJECT_RAW_BASE) raw_base="$value" ;;
+        Z2R_BRANCH) ref="$value" ;;
+        Z2R_REPOSITORY) repository="$value" ;;
+        Z2R_COMMIT) commit="$value" ;;
+      esac
+    done < "$Z2R_UPDATE_CONFIG"
+  fi
+
+  [ -n "$repository" ] && raw_base="https://raw.githubusercontent.com/$repository"
+  [ -n "$commit" ] && ref="$commit"
+  [ -n "$Z2R_ENV_SOURCE_RAW_BASE" ] && raw_base="$Z2R_ENV_SOURCE_RAW_BASE"
+  [ -n "$Z2R_ENV_SOURCE_REPOSITORY" ] && raw_base="https://raw.githubusercontent.com/$Z2R_ENV_SOURCE_REPOSITORY"
+  [ -n "$Z2R_ENV_SOURCE_REF" ] && ref="$Z2R_ENV_SOURCE_REF"
+  [ -n "$Z2R_ENV_SOURCE_COMMIT" ] && ref="$Z2R_ENV_SOURCE_COMMIT"
+
+  # Старый контракт позволял передать уже собранный raw URL, включая ref.
+  # Если отдельный Z2R_BRANCH не задан, извлекаем его и приводим base к root.
+  if [ -z "$Z2R_ENV_SOURCE_REF" ] && [ -z "$Z2R_ENV_SOURCE_COMMIT" ]; then
+    case "$raw_base" in
+      https://raw.githubusercontent.com/*/*/*|http://raw.githubusercontent.com/*/*/*)
+        legacy_path="${raw_base#*://}"
+        legacy_path="${legacy_path#*/}"
+        legacy_path="${legacy_path#*/}"
+        legacy_path="${legacy_path#*/}"
+        if [ -n "$legacy_path" ]; then
+          ref="$legacy_path"
+          raw_base="${raw_base%/$legacy_path}"
+        fi
+        ;;
+    esac
+  fi
+
+  z2r_source_validate_base "$raw_base" || { z2r_source_config_error "некорректный project source"; return 1; }
+  z2r_source_validate_ref "$ref" || { z2r_source_config_error "некорректный installation ref"; return 1; }
+  [ -z "$repository" ] || z2r_source_validate_repository "$repository" || {
+    z2r_source_config_error "repository должен иметь вид owner/name"; return 1;
+  }
+  if [ -n "$commit" ]; then
+    z2r_source_validate_sha "$commit" || { z2r_source_config_error "commit должен быть полным 40-символьным SHA"; return 1; }
+  fi
+  if [ -n "$Z2R_ENV_SOURCE_COMMIT" ]; then
+    z2r_source_validate_sha "$Z2R_ENV_SOURCE_COMMIT" || { z2r_source_config_error "Z2R_COMMIT должен быть полным 40-символьным SHA"; return 1; }
+  fi
+
+  Z2R_SOURCE_RAW_BASE="$raw_base"
+  Z2R_SOURCE_REF="$ref"
+  Z2R_SOURCE_CONFIG_PRESENT="$config_present"
+  if [ -n "$Z2R_ENV_SOURCE_RAW_BASE" ] || [ -n "$Z2R_ENV_SOURCE_REF" ] || [ -n "$Z2R_ENV_SOURCE_REPOSITORY" ] || [ -n "$Z2R_ENV_SOURCE_COMMIT" ]; then
+    Z2R_SOURCE_CONFIG_ORIGIN="environment"
+  elif [ "$config_present" -eq 1 ]; then
+    Z2R_SOURCE_CONFIG_ORIGIN="config"
+  else
+    Z2R_SOURCE_CONFIG_ORIGIN="default"
+  fi
+  export Z2R_SOURCE_RAW_BASE Z2R_SOURCE_REF Z2R_SOURCE_CONFIG_PRESENT Z2R_SOURCE_CONFIG_ORIGIN
+}
+
+z2r_source_write_config() {
+  local raw_base="$1" ref="$2" tmp="${Z2R_UPDATE_CONFIG}.tmp.$$" old_umask
+  z2r_source_validate_base "$raw_base" || { echo "Некорректный project source: $raw_base" >&2; return 1; }
+  z2r_source_validate_ref "$ref" || { echo "Некорректный installation ref: $ref" >&2; return 1; }
+  mkdir -p "$Z2R_UPDATE_DIR" || return 1
+  old_umask="$(umask)"
+  umask 077
+  {
+    printf 'Z2R_PROJECT_RAW_BASE="%s"\n' "$raw_base"
+    printf 'Z2R_BRANCH="%s"\n' "$ref"
+  } > "$tmp" || { umask "$old_umask"; rm -f "$tmp"; return 1; }
+  umask "$old_umask"
+  if [ -f "$Z2R_UPDATE_CONFIG" ] && cmp -s "$tmp" "$Z2R_UPDATE_CONFIG"; then
+    rm -f "$tmp"
+  else
+    mv -f "$tmp" "$Z2R_UPDATE_CONFIG"
+  fi
+}
+
+if ! z2r_source_load_config; then
+  exit 1
+fi
+
 
 z2r_github_commit_date() {
   local path="$1" timeout="${2:-10}"
@@ -40,6 +217,7 @@ Z2R_BRANCH="${Z2R_BRANCH:-zator}"
 Z2R_PROJECT_RAW_BASE="${Z2R_PROJECT_RAW_BASE:-https://raw.githubusercontent.com/AloofLibra/zator/${Z2R_BRANCH}}"
 Z2R_PROJECT_MIRROR_BASE="${Z2R_PROJECT_MIRROR_BASE:-https://git.px.rkn.quest/AloofLibra/plain}"
 Z2R_INSTALLER_URL="${Z2R_INSTALLER_URL:-${Z2R_PROJECT_RAW_BASE}/z2r.sh}"
+Z2R_LEGACY_INSTALLER_URL="${Z2R_LEGACY_INSTALLER_URL:-https://git.px.rkn.quest/AloofLibra/plain/z2r.sh?h=zator}"
 ZAPRET2_UPSTREAM_RAW_BASE="${ZAPRET2_UPSTREAM_RAW_BASE:-https://raw.githubusercontent.com/bol-van/zapret2/master}"
 ZAPRET2_UPSTREAM_MIRROR_BASE="${ZAPRET2_UPSTREAM_MIRROR_BASE:-https://git.px.rkn.quest/zapret2/plain}"
 ZAPRET2_RELEASE_BASE="${ZAPRET2_RELEASE_BASE:-https://github.com/bol-van/zapret2/releases/download}"
@@ -66,6 +244,186 @@ z2r_fetch_url_to_file() {
   return 127
 }
 
+z2r_fetch_url_stdout() {
+  local url="$1"
+
+  if command -v curl >/dev/null 2>&1; then
+    curl -fsSL "$url"
+    return $?
+  fi
+  if command -v wget >/dev/null 2>&1; then
+    wget -qO- "$url"
+    return $?
+  fi
+  return 127
+}
+
+z2r_source_repository_from_base() {
+  local base="$1" rest owner repository
+  case "$base" in
+    */*) ;;
+    *) return 1 ;;
+  esac
+
+  case "$base" in
+    https://github.com/*|http://github.com/*|https://www.github.com/*|http://www.github.com/*)
+      rest="${base#*://}"
+      rest="${rest#*/}"
+      ;;
+    https://raw.githubusercontent.com/*|http://raw.githubusercontent.com/*)
+      rest="${base#*://}"
+      rest="${rest#*/}"
+      ;;
+    [A-Za-z0-9_.-]*/[A-Za-z0-9_.-]*)
+      z2r_source_validate_repository "$base" || return 1
+      printf '%s\n' "$base"
+      return 0
+      ;;
+    *) return 1 ;;
+  esac
+
+  owner="${rest%%/*}"
+  rest="${rest#*/}"
+  repository="${rest%%/*}"
+  [ -n "$owner" ] && [ -n "$repository" ] || return 1
+  z2r_source_validate_repository "$owner/$repository" || return 1
+  printf '%s/%s\n' "$owner" "$repository"
+}
+
+z2r_source_raw_root() {
+  local repository="$1" raw_base="$2"
+  if [ -n "$repository" ]; then
+    printf 'https://raw.githubusercontent.com/%s\n' "$repository"
+  else
+    printf '%s\n' "${raw_base%/}"
+  fi
+}
+
+z2r_source_resolve_ref() {
+  local repository="$1" ref="$2" response commit
+
+  if z2r_source_validate_sha "$ref"; then
+    printf '%s\n' "$ref"
+    return 0
+  fi
+  [ -n "$repository" ] || return 1
+
+  response="$(z2r_fetch_url_stdout "${Z2R_GITHUB_API_BASE:-https://api.github.com}/repos/${repository}/commits/${ref}")" || return 1
+  commit="$(printf '%s\n' "$response" | sed -n 's/.*"sha"[[:space:]]*:[[:space:]]*"\([A-Fa-f0-9][A-Fa-f0-9]*\)".*/\1/p' | head -n 1)"
+  z2r_source_validate_sha "$commit" || return 1
+  printf '%s\n' "$commit"
+}
+
+z2r_source_prepare() {
+  local repository raw_root commit
+  repository="$(z2r_source_repository_from_base "$Z2R_SOURCE_RAW_BASE" 2>/dev/null || true)"
+  raw_root="$(z2r_source_raw_root "$repository" "$Z2R_SOURCE_RAW_BASE")"
+  commit="$(z2r_source_resolve_ref "$repository" "$Z2R_SOURCE_REF")" || {
+    echo "Не удалось разрешить installation ref '$Z2R_SOURCE_REF' в точный commit." >&2
+    return 1
+  }
+
+  Z2R_SOURCE_REPOSITORY="$repository"
+  Z2R_SOURCE_RAW_ROOT="$raw_root"
+  Z2R_SOURCE_RESOLVED_COMMIT="$commit"
+  Z2R_SOURCE_STRICT=1
+  export Z2R_SOURCE_REPOSITORY Z2R_SOURCE_RAW_ROOT Z2R_SOURCE_RESOLVED_COMMIT Z2R_SOURCE_STRICT
+}
+
+z2r_source_raw_url() {
+  local rel="$1"
+  case "$rel" in ''|/*|*'..'*) return 1 ;; esac
+  [ -n "${Z2R_SOURCE_RAW_ROOT:-}" ] || return 1
+  [ -n "${Z2R_SOURCE_RESOLVED_COMMIT:-}" ] || return 1
+  printf '%s/%s/%s\n' "$Z2R_SOURCE_RAW_ROOT" "$Z2R_SOURCE_RESOLVED_COMMIT" "$rel"
+}
+
+z2r_launcher_path() {
+  local launcher="${1:-$0}" target attempts=0
+  if [ "$#" -eq 0 ] && [ -n "${Z2R_LAUNCHER_PATH:-}" ]; then
+    printf '%s\n' "$Z2R_LAUNCHER_PATH"
+    return 0
+  fi
+  if [ "${launcher#*/}" = "$launcher" ]; then
+    launcher="$(command -v "$launcher" 2>/dev/null)" || return 1
+  fi
+  while [ -L "$launcher" ] && [ "$attempts" -lt 8 ]; do
+    target="$(readlink "$launcher" 2>/dev/null)" || return 1
+    case "$target" in
+      /*) launcher="$target" ;;
+      *) launcher="$(dirname -- "$launcher")/$target" ;;
+    esac
+    attempts=$((attempts + 1))
+  done
+  [ ! -L "$launcher" ] || return 1
+  cd -- "$(dirname -- "$launcher")" 2>/dev/null || return 1
+  printf '%s/%s\n' "$(pwd)" "$(basename -- "$launcher")"
+}
+
+z2r_bootstrap_refresh_launcher() {
+  local launcher tmp url shell_bin
+  [ "${Z2R_DISABLE_SELF_REFRESH:-0}" = "1" ] && return 0
+  [ "${Z2R_SELF_REFRESHED:-0}" = "1" ] && return 0
+  launcher="$(z2r_launcher_path)" || return 0
+  case "$launcher" in
+    /opt/*) ;;
+    "${Z2R_SELF_REFRESH_ROOT:-/nonexistent}"/*) [ -n "${Z2R_SELF_REFRESH_ROOT:-}" ] || return 0 ;;
+    *) return 0 ;;
+  esac
+  if [ -z "${Z2R_LAUNCHER_PATH:-}" ] && [ "$(basename -- "$launcher")" != "z2r.sh" ]; then
+    return 0
+  fi
+  z2r_source_prepare >/dev/null 2>&1 || return 0
+  url="$(z2r_source_raw_url z2r.sh)" || return 0
+  tmp="${launcher}.new.$$"
+  rm -f "$tmp"
+  z2r_fetch_url_to_file "$tmp" "$url" || { rm -f "$tmp"; return 0; }
+  bash -n "$tmp" >/dev/null 2>&1 || { rm -f "$tmp"; return 0; }
+  if cmp -s "$tmp" "$launcher"; then
+    rm -f "$tmp"
+    return 0
+  fi
+  chmod 755 "$tmp" 2>/dev/null || true
+  mv -f "$tmp" "$launcher" || { rm -f "$tmp"; return 0; }
+  shell_bin="$(command -v bash 2>/dev/null || true)"
+  [ -n "$shell_bin" ] || return 0
+  Z2R_SELF_REFRESHED=1 exec "$shell_bin" "$launcher" "$@"
+}
+
+z2r_install_persistent_launcher() {
+  local command_launcher="${Z2R_COMMAND_LAUNCHER:-/opt/bin/z2r}"
+  local runtime_launcher="${Z2R_RUNTIME_LAUNCHER:-/opt/z2r.sh}"
+  local backup="${Z2R_UPDATE_DIR}/legacy-bootstrap.z2r"
+  local shell_bin tmp old_umask
+
+  [ "${Z2R_DISABLE_PERSISTENT_LAUNCHER:-0}" = "1" ] && return 0
+  [ -x "$runtime_launcher" ] || return 0
+  mkdir -p "$(dirname "$command_launcher")" "$Z2R_UPDATE_DIR" || return 1
+  shell_bin="$(command -v bash 2>/dev/null || true)"
+  [ -n "$shell_bin" ] || return 0
+  if [ -f "$command_launcher" ] && grep -F '# z2r persistent launcher' "$command_launcher" >/dev/null 2>&1; then
+    return 0
+  fi
+  if [ -f "$command_launcher" ] && [ ! -e "$backup" ]; then
+    cp -p "$command_launcher" "$backup" || return 1
+  fi
+  tmp="${command_launcher}.new.$$"
+  old_umask="$(umask)"
+  umask 022
+  {
+    printf '%s\n' '#!/bin/sh'
+    printf '%s\n' '# z2r persistent launcher'
+    printf 'exec "%s" "%s" "$@"\n' "$shell_bin" "$runtime_launcher"
+  } > "$tmp" || { umask "$old_umask"; rm -f "$tmp"; return 1; }
+  umask "$old_umask"
+  chmod 755 "$tmp" || { rm -f "$tmp"; return 1; }
+  if cmp -s "$tmp" "$command_launcher"; then
+    rm -f "$tmp"
+  else
+    mv -f "$tmp" "$command_launcher"
+  fi
+}
+
 z2r_download_project_file() {
   local dest="$1"
   local rel="$2"
@@ -73,13 +431,29 @@ z2r_download_project_file() {
   local primary="${Z2R_PROJECT_RAW_BASE}/${rel}"
   local mirror
 
-  mirror="$(z2r_mirror_url "$rel")"
+  if [ "${Z2R_SOURCE_STRICT:-0}" != "1" ]; then
+    z2r_source_prepare || return 1
+  fi
+  if [ "${Z2R_SOURCE_STRICT:-0}" = "1" ]; then
+    primary="$(z2r_source_raw_url "$rel")" || return 1
+    mirror=""
+  else
+    mirror="$(z2r_mirror_url "$rel")"
+  fi
   mkdir -p "$(dirname "$dest")"
   rm -f "$tmp"
-  if z2r_fetch_url_to_file "$tmp" "$primary"; then
+  if type z2r_source_cache_restore >/dev/null 2>&1 && z2r_source_cache_restore "$rel" "$tmp"; then
     mv -f "$tmp" "$dest"
+    type z2r_source_track_file >/dev/null 2>&1 && z2r_source_track_file "$dest" "$rel"
     return 0
   fi
+  if z2r_fetch_url_to_file "$tmp" "$primary"; then
+    type z2r_source_cache_store >/dev/null 2>&1 && z2r_source_cache_store "$rel" "$tmp" || true
+    mv -f "$tmp" "$dest"
+    type z2r_source_track_file >/dev/null 2>&1 && z2r_source_track_file "$dest" "$rel"
+    return 0
+  fi
+  [ -n "$mirror" ] || { rm -f "$tmp"; return 1; }
   echo -e "${yellow}GitHub недоступен для $rel. Пробую зеркало.${plain}" >&2
   rm -f "$tmp"
   if z2r_fetch_url_to_file "$tmp" "$mirror"; then
@@ -198,12 +572,19 @@ z2r_download_zapret2_release() {
 }
 
 z2r_exec_external_installer() {
-  local mirror
+  local installer_url="" shell_bin
   local tmp="/tmp/z2r_installer_$$"
 
-  mirror="$(z2r_mirror_url "z2r")"
-  if z2r_fetch_url_to_file "$tmp" "$Z2R_INSTALLER_URL" || z2r_fetch_url_to_file "$tmp" "$mirror"; then
-    exec sh "$tmp" "$@"
+  if z2r_source_prepare >/dev/null 2>&1; then
+    installer_url="$(z2r_source_raw_url z2r.sh)"
+    if z2r_fetch_url_to_file "$tmp" "$installer_url"; then
+      shell_bin="$(command -v bash 2>/dev/null || true)"
+      [ -n "$shell_bin" ] && exec "$shell_bin" "$tmp" "$@"
+    fi
+  fi
+  if [ "$Z2R_SOURCE_CONFIG_ORIGIN" = "default" ] && z2r_fetch_url_to_file "$tmp" "$Z2R_LEGACY_INSTALLER_URL"; then
+    shell_bin="$(command -v bash 2>/dev/null || true)"
+    [ -n "$shell_bin" ] && exec "$shell_bin" "$tmp" "$@"
   fi
   rm -f "$tmp"
   echo "Ошибка: не удалось загрузить внешний z2r."
@@ -228,6 +609,30 @@ done
 if [ "$missing_libs" -ne 0 ]; then
   echo "Не найдены нужные файлы в $LIB_DIR. Запускаю внешний z2r..."
   z2r_exec_external_installer "$@"
+fi
+
+z2r_bootstrap_sync_updater_module() {
+  local dest="$LIB_DIR/updater.sh" tmp url
+  [ -d "$LIB_DIR" ] || return 1
+  [ -s "$dest" ] && return 0
+  z2r_source_prepare >/dev/null 2>&1 || return 1
+  url="$(z2r_source_raw_url lib/updater.sh)" || return 1
+  tmp="${dest}.tmp.$$"
+  rm -f "$tmp"
+  z2r_fetch_url_to_file "$tmp" "$url" || { rm -f "$tmp"; return 1; }
+  bash -n "$tmp" >/dev/null 2>&1 || { rm -f "$tmp"; return 1; }
+  chmod 644 "$tmp" 2>/dev/null || true
+  mv -f "$tmp" "$dest"
+}
+
+z2r_bootstrap_sync_updater_module || true
+if [ -s "$LIB_DIR/updater.sh" ]; then
+  # shellcheck disable=SC1090
+  source "$LIB_DIR/updater.sh"
+elif [ -s "$SCRIPT_DIR/lib/updater.sh" ]; then
+  # Удобно для запуска из checkout; на роутере используется только runtime-копия.
+  # shellcheck disable=SC1090
+  source "$SCRIPT_DIR/lib/updater.sh"
 fi
 
 #___Общие вспомогательные функции____
@@ -413,28 +818,20 @@ ORCH_LUA_LOCKED="/opt/zapret2/lua/locked.lua"
 RST_GUARD_LUA="/opt/zapret2/lua/rst-guard.lua"
 
 locked_lua_update_from_repo() {
-  local tmp="${ORCH_LUA_LOCKED}.tmp"
-
   mkdir -p "$ORCH_DIR" "$(dirname "$ORCH_LUA_LOCKED")"
-  if ! z2r_download_project_file "$tmp" "orchestra/locked.lua"; then
+  if ! z2r_download_project_file "$ORCH_LUA_LOCKED" "orchestra/locked.lua"; then
     echo -e "${red}Не удалось скачать locked.lua.${plain}"
     return 1
   fi
-
-  mv "$tmp" "$ORCH_LUA_LOCKED"
   echo -e "${green}locked.lua обновлен из репозитория.${plain}"
 }
 
 rst_guard_lua_update_from_repo() {
-  local tmp="${RST_GUARD_LUA}.tmp"
-
   mkdir -p "$(dirname "$RST_GUARD_LUA")"
-  if ! z2r_download_project_file "$tmp" "lua/rst-guard.lua"; then
+  if ! z2r_download_project_file "$RST_GUARD_LUA" "lua/rst-guard.lua"; then
     echo -e "${red}Не удалось скачать rst-guard.lua.${plain}"
     return 1
   fi
-
-  mv "$tmp" "$RST_GUARD_LUA"
   echo -e "${green}rst-guard.lua обновлен из репозитория.${plain}"
 }
 
@@ -814,12 +1211,67 @@ run_cdn_test() {
   echo -e "${RED}FAIL:${NC} ${FAIL_COUNT:-0}"
 }
 
+# Скачивает обязательный набор zator в SHA-scoped cache до удаления runtime.
+# Так сетевой сбой не оставляет пользователя без уже работавшего /opt/zapret2.
+z2r_stage_project_core() {
+  local stage_dir rel safe_rel
+  local -a project_files=(
+    "orchestra/locked.lua"
+    "lua/rst-guard.lua"
+    "lists/cloudflare-ipset.txt"
+    "lists/cloudflare-ipset_v6.txt"
+    "lists/netrogat.txt"
+    "lists/russia-discord.txt"
+    "lists/russia-youtube-rtmps.txt"
+    "lists/russia-youtube.txt"
+    "lists/russia-youtubeQ.txt"
+    "lists/tg_cidr.txt"
+    "fake_files.tar.gz"
+    "fake/custom_tls.bin"
+    "extra_strats/UDP/YT/List.txt"
+    "extra_strats/TCP/RKN/List.txt"
+    "extra_strats/TCP/RKN/Custom.txt"
+    "extra_strats/TCP/YT/List.txt"
+    "extra_strats/TCP/RKN/Discord.txt"
+    "extra_strats/TCP/RKN/Domains_By_Substring.txt"
+    "blockcheck2.d/z4r/10-list.sh"
+    "blockcheck2.d/z4r/list_https_tls12.txt"
+    "blockcheck2.d/z4r/list_https_tls13.txt"
+    "config.default"
+  )
+
+  for rel in "${Z2R_RUNTIME_LIBRARIES[@]}"; do
+    project_files+=("lib/$rel")
+  done
+
+  [ "$hardware" = "keenetic" ] && project_files+=("Entware/keenetic-policy.sh")
+  [ "$OSystem" = "entware" ] && project_files+=("Entware/zapret" "Entware/000-zapret.sh" "Entware/S00fix")
+  stage_dir="$(mktemp -d /tmp/z2r-project-stage.XXXXXX)" || return 1
+  for rel in "${project_files[@]}"; do
+    safe_rel="$(printf '%s' "$rel" | tr '/' '@')"
+    if ! z2r_download_project_file "$stage_dir/$safe_rel" "$rel"; then
+      rm -rf "$stage_dir"
+      echo "Не удалось подготовить $rel из выбранного source." >&2
+      return 1
+    fi
+  done
+  rm -rf "$stage_dir"
+}
+
 #Создаём папки и забираем файлы папок lists, fake, extra_strats, копируем конфиг
 get_repo() {
   local fake_archive="/tmp/z2r_fake_files_$$.tar.gz"
 
+  z2r_source_prepare || return 1
+  if type z2r_source_track_begin >/dev/null 2>&1; then
+    z2r_source_track_begin || return 1
+  fi
   mkdir -p /opt/zapret2/lists /opt/zapret2/extra_strats /opt/zapret2/extra_strats/cache /opt/zapret2/files/fake
   mkdir -p /opt/zapret2/extra_strats/cache/orchestra
+  mkdir -p /opt/zapret2/z2r_lib
+  for lib in "${Z2R_RUNTIME_LIBRARIES[@]}"; do
+    z2r_download_project_file "/opt/zapret2/z2r_lib/$lib" "lib/$lib" || return 1
+  done
   chmod 777 /opt/zapret2/extra_strats/cache/orchestra 2>/dev/null || true
   locked_lua_update_from_repo || true
   rst_guard_lua_update_from_repo || true
@@ -1514,7 +1966,13 @@ get_menu() {
     update_recommendations  
   while true; do
   	local strategies_status
+    local source_status
     strategies_status=$(get_orchestra_locks_info)
+	if type z2r_source_status_line >/dev/null 2>&1; then
+	  source_status="$(z2r_source_status_line)"
+	else
+	  source_status="${Z2R_SOURCE_RAW_BASE} @ ${Z2R_SOURCE_REF}"
+	fi
 	TITLE_MENU_LINE=""
     if [[ -s "$PREMIUM_TITLE_FILE" ]]; then
       TITLE_MENU_LINE="\n${pink}Титул:${plain} $(cat "$PREMIUM_TITLE_FILE")${yellow}\n"
@@ -1538,6 +1996,7 @@ get_menu() {
 '"\033[32mЯ черепашка Дейв. И я медленный.\033[33m"'
 '"\033[32mПрямо как твой интернет.\033[33m"'
 
+'"${yellow}"'Источник zator: '"${plain}${source_status}${yellow}"'
 
 '"Город/провайдер: ${plain}${PROVIDER_MENU}${yellow}"'
 '"${TITLE_MENU_LINE}"'
@@ -1758,6 +2217,19 @@ esac
 
 #___Само выполнение скрипта начинается тут____
 
+if [ "${1:-}" = "source" ]; then
+  if type z2r_source_command >/dev/null 2>&1; then
+    z2r_source_command "${@:2}"
+    exit $?
+  fi
+  echo "Модуль updater ещё не установлен. Выполните полное обновление z2r при доступной сети." >&2
+  exit 1
+fi
+
+z2r_bootstrap_refresh_launcher "$@" || true
+z2r_install_persistent_launcher || \
+  echo -e "${yellow}Не удалось обновить постоянный launcher z2r; текущий запуск продолжится.${plain}" >&2
+
 
 detect_os
 set_zapret2_init
@@ -1801,6 +2273,21 @@ fi
 mkdir -p /opt
 cd /tmp
 
+# До удаления текущего runtime убеждаемся, что все project-файлы будут взяты из
+# одного exact commit выбранного источника.
+if ! z2r_source_prepare; then
+  echo -e "${red}Обновление отменено: источник zator недоступен или ref не разрешён.${plain}" >&2
+  exit 1
+fi
+if ! z2r_stage_project_core; then
+  echo -e "${red}Обновление отменено: не удалось подготовить файлы выбранного source.${plain}" >&2
+  exit 1
+fi
+if ! orch_runtime_state_snapshot "$ORCH_DIR" "$Z2R_ORCHESTRA_SNAPSHOT_DIR"; then
+  echo -e "${red}Обновление отменено: не удалось сохранить состояния стратегий.${plain}" >&2
+  exit 1
+fi
+
 #Удаление старого запрета, если есть
 remove_zapret
 
@@ -1824,6 +2311,10 @@ zapret_get
 
 #Создаём папки и забираем файлы папок lists, fake, extra_strats, копируем конфиг, скрипты для войсов DS, WA, TG
 get_repo
+if ! orch_runtime_state_restore "$ORCH_DIR" "$Z2R_ORCHESTRA_SNAPSHOT_DIR"; then
+  echo -e "${red}Не удалось восстановить состояния стратегий после обновления.${plain}" >&2
+  exit 1
+fi
 if [ ! -s "$ORCH_LUA_LOCKED" ]; then
   echo "Повторная попытка загрузки locked.lua..."
   if locked_lua_update_from_repo; then
@@ -1850,5 +2341,8 @@ fi
 #Запуск установочных скриптов и перезагрузка
 if [ "$hardware" = "keenetic" ]; then
  ensure_keenetic_policy_config /opt/zapret2/config.default
+fi
+if type z2r_source_track_finish >/dev/null 2>&1; then
+  z2r_source_track_finish || exit 1
 fi
 install_zapret_reboot


### PR DESCRIPTION
## Что меняется

Обновление z2r теперь привязано к конкретному commit выбранного источника: сначала ref (ветка, тег или SHA) разрешается в SHA, а затем все файлы одной установки берутся только из этого commit. Файлы дополнительно складываются в SHA-scoped кэш с проверкой SHA-256.

Появился постоянный локальный launcher. Он постепенно заменяет старый bootstrap-скрипт, поэтому обычным пользователям не нужно менять привычную команду `z2r`.

Во время полной переустановки сохраняются стратегии и lock-файлы orchestra. Это важно для старых установок, где выбранные стратегии могли жить только внутри `/opt/zapret2`.

TUI показывает источник, запрошенный ref, commit последней полной установки и наличие локальных изменений runtime.

## Как пользоваться

Для обычного пользователя ничего делать не нужно: запускайте `z2r` как раньше. При первом обычном запуске старый bootstrap будет заменён на совместимый локальный launcher.

Если нужно установить свою сборку:

```sh
z2r source set owner/repository branch
```

Вместо ветки можно указать тег или полный 40-символьный SHA. Команда только сохраняет выбор; обновление начнётся после обычного подтверждённого обновления z2r.

Полезные команды:

```sh
z2r source show          # текущий источник, ref и установленный commit
z2r source pin           # закрепить текущий ref на разрешённом SHA
z2r source pin <sha>     # закрепить на указанном SHA
z2r source reset         # вернуться к штатному источнику и синхронизировать файлы
```

Для автоматизации также поддерживаются `Z2R_PROJECT_RAW_BASE` и `Z2R_BRANCH`. Первый параметр принимает `owner/repository` или прежний raw URL; второй — ветку, тег или SHA. Значения из окружения имеют приоритет над `/opt/etc/z2r/update.conf` и не сохраняются в файл.

## Совместимость

- Старый контракт `Z2R_PROJECT_RAW_BASE` сохранён.
- Legacy raw URL и ранние aliases источника поддерживаются как fallback.
- Настройки источника не смешиваются с canonical mirror.
- При сетевой ошибке до удаления runtime обновление отменяется: обязательные файлы сначала подготавливаются в кэше.

## Проверка

- `bash tests/updater_source_config_smoke.sh`
- `bash tests/updater_cli_smoke.sh`
- `bash tests/profile_lock_smoke.sh`
- Полный update проверен на Keenetic/Entware: launcher, manifest, SHA-кэш, восстановление стратегий и запуск `nfqws2`.